### PR TITLE
[BSVR-61] 윈도우에서 makeGitHooksExecutable 에러 fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,11 @@ subprojects {
     }
 
     tasks.register<Exec>("makeGitHooksExecutable") {
-        commandLine("chmod", "+x", "${rootProject.rootDir}/.git/hooks/pre-commit")
+        if (System.getProperty("os.name").contains("Windows")) {
+            commandLine("attrib", "+x", "${rootProject.rootDir}/.git/hooks/pre-commit")
+        } else {
+            commandLine("chmod", "+x", "${rootProject.rootDir}/.git/hooks/pre-commit")
+        }
         dependsOn("updateGitHooks")
     }
 


### PR DESCRIPTION
## 📌 개요 (필수)

- makeGitHooksExecutable 에러 fix

<br>

## 🔨 작업 사항 (필수)

- OS에 따른 명령어 분기처리
  - Windows : attrib
  - 그 외 : chmod

<br>

## ⚡️ 관심 리뷰 (선택)

- Mac에서도 정상 동작하는지 확인해줬으면 해! ㅎㅎ
