### PR TITLE
[BSVR-62] 개발단계 ci github actions 스크립트 추가

### DIFF
--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -1,0 +1,75 @@
+name: Development Auto Deployment
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+  pull_request:
+    branches:
+      - dev
+      - main
+
+concurrency:
+  group: deploy_dev
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "corretto"
+
+      - name: Cache Gradle
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build -x test --stacktrace --parallel
+
+      - name: Run tests
+        run: ./gradlew test
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: '**/build/test-results/test/TEST-*.xml'
+
+      - name: JUnit Report Action
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+
+      - name: Store test results
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test-results
+          path: '**/build/test-results/test/TEST-*.xml'
+
+      - name: Test Report Summary
+        if: always()
+        run: |
+          echo '## Test Report Summary' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          ./gradlew test --console=plain || true
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -10,10 +10,6 @@ on:
       - dev
       - main
 
-concurrency:
-  group: deploy_dev
-  cancel-in-progress: true
-
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -10,9 +10,9 @@ on:
       - dev
       - main
 
-#concurrency:
-#  group: deploy_dev
-#  cancel-in-progress: true
+concurrency:
+  group: deploy_dev
+  cancel-in-progress: true
 
 jobs:
   build-and-test:

--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -1,4 +1,4 @@
-name: Development Auto Deployment
+name: Build And Test
 
 on:
   push:
@@ -10,9 +10,9 @@ on:
       - dev
       - main
 
-concurrency:
-  group: deploy_dev
-  cancel-in-progress: true
+#concurrency:
+#  group: deploy_dev
+#  cancel-in-progress: true
 
 jobs:
   build-and-test:

--- a/.github/workflows/pr-size-labeler.yaml
+++ b/.github/workflows/pr-size-labeler.yaml
@@ -1,8 +1,6 @@
 name: PR-size-labeler
 
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+on: [pull_request]
 
 jobs:
   labeler:

--- a/.github/workflows/pr-size-labeler.yaml
+++ b/.github/workflows/pr-size-labeler.yaml
@@ -1,6 +1,8 @@
 name: PR-size-labeler
 
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   labeler:


### PR DESCRIPTION

## 📌 개요 (필수)

- build와 test를 포함하는 dev용 CI github action 스크립트 작성

<br>

## 🔨 작업 사항 (필수)

- 작업 순서
1. [publish-unit-test-result-action](https://github.com/EnricoMi/publish-unit-test-result-action) : action 안들어가도 테스트 결과 확인 가능
2. [action-junit-report](https://github.com/mikepenz/action-junit-report) : 실패한 테스트를 PR 란에서 바로 확인 가능
3. [Store test results](https://github.com/actions/upload-artifact) 스텝을 추가하여 테스트 결과를 아티팩트로 저장함. 워크플로우 실행 후에도 결과를 다운로드하여 확인할 수 있음
4. Test Report Summary: 간단한 테스트 결과 요약을 GitHub Actions 실행 페이지에 표시함.

<br>

## ⚡️ 관심 리뷰 (선택)

- x

<br>

## 🌱 연관 내용 (선택)

- 지금은 main 브랜치에 작업중이라 workflow on 트리거에 main 브랜치를 포함시켰는데, 이 작업은 dev용이라 실제 개발 들어가면 삭제할 예정!
- ncp 크레딧 받아서 인프라 세팅하면 자동배포 추가해 dev-cicd로 업그레이드 예정(환경변수 세팅 필요)
