### PR TITLE
[BSVR-55] P6spy를 이용한 쿼리 로그 설정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,11 @@ subprojects {
     }
 
     tasks.register<Exec>("makeGitHooksExecutable") {
-        commandLine("chmod", "+x", "${rootProject.rootDir}/.git/hooks/pre-commit")
+        if (System.getProperty("os.name").contains("Windows")) {
+            commandLine("attrib", "+x", "${rootProject.rootDir}/.git/hooks/pre-commit")
+        } else {
+            commandLine("chmod", "+x", "${rootProject.rootDir}/.git/hooks/pre-commit")
+        }
         dependsOn("updateGitHooks")
     }
 

--- a/infrastructure/jpa/build.gradle.kts
+++ b/infrastructure/jpa/build.gradle.kts
@@ -5,6 +5,9 @@ dependencies {
     // spring
     implementation("org.springframework.boot:spring-boot-starter-data-jpa:_")
 
+    // p6spy
+    implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:_")
+
     // h2 - DB (또는 도커) 세팅 후 사라질 예정,,
     runtimeOnly("com.h2database:h2")
 

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/common/P6spySqlFormatter.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/common/P6spySqlFormatter.java
@@ -11,7 +11,7 @@ import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
 @Configuration
 public class P6spySqlFormatter implements MessageFormattingStrategy {
 
-    private static String JPA_PACKAGE = "org.depromeet.spot";
+    private static String ROOT_PACKAGE = "org.depromeet.spot";
     private static String P6SPY_PACKAGE = "org.depromeet.spot.jpa.common.P6spySqlFormatter";
 
     @Override
@@ -61,7 +61,7 @@ public class P6spySqlFormatter implements MessageFormattingStrategy {
 
         for (StackTraceElement element : stackTraces) {
             String trace = element.toString();
-            if (trace.startsWith(JPA_PACKAGE) && !trace.contains(P6SPY_PACKAGE)) {
+            if (trace.startsWith(ROOT_PACKAGE) && !trace.contains(P6SPY_PACKAGE)) {
                 sb.append("\n\t\t").append(order++).append(".").append(trace);
             }
         }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/common/P6spySqlFormatter.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/common/P6spySqlFormatter.java
@@ -1,0 +1,70 @@
+package org.depromeet.spot.jpa.common;
+
+import java.util.Locale;
+
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+import org.springframework.context.annotation.Configuration;
+
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+
+@Configuration
+public class P6spySqlFormatter implements MessageFormattingStrategy {
+
+    private static String JPA_PACKAGE = "org.depromeet.spot.jpa";
+    private static String P6SPY_PACKAGE = "org.depromeet.spot.jpa.config.P6spySqlFormatter";
+
+    @Override
+    public String formatMessage(
+            int connectionId,
+            String now,
+            long elapsed,
+            String category,
+            String prepared,
+            String sql,
+            String url) {
+        sql = formatSql(category, sql);
+        return String.format(
+                "[%s] | took %d ms | connectionId %d | %s | %s",
+                category, elapsed, connectionId, filterStack(), formatSql(category, sql));
+    }
+
+    private String formatSql(String category, String sql) {
+        if (isNotEmpty(sql) && isStatement(category)) {
+            String trimmedSQL = sql.trim().toLowerCase(Locale.ROOT);
+            if (isDDL(trimmedSQL)) {
+                return FormatStyle.DDL.getFormatter().format(sql);
+            }
+            return FormatStyle.BASIC.getFormatter().format(sql);
+        }
+        return sql;
+    }
+
+    // 일반적인 쿼리인지 판단
+    // 트랜잭션 커밋, 롤백 등 쿼리가 아닌 작업은 포맷팅하지 않는다.
+    private boolean isStatement(String category) {
+        return Category.STATEMENT.getName().equals(category);
+    }
+
+    private boolean isNotEmpty(String sql) {
+        return sql != null && !sql.trim().isEmpty();
+    }
+
+    private boolean isDDL(String sql) {
+        return (sql.startsWith("create")) || sql.startsWith("alter") || sql.startsWith("comment");
+    }
+
+    private String filterStack() {
+        StackTraceElement[] stackTraces = new Throwable().getStackTrace();
+        StringBuilder sb = new StringBuilder();
+        int order = 1;
+
+        for (StackTraceElement element : stackTraces) {
+            String trace = element.toString();
+            if (trace.startsWith(JPA_PACKAGE) && !trace.contains(P6SPY_PACKAGE)) {
+                sb.append("\n\t\t").append(order++).append(".").append(trace);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/common/P6spySqlFormatter.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/common/P6spySqlFormatter.java
@@ -11,8 +11,8 @@ import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
 @Configuration
 public class P6spySqlFormatter implements MessageFormattingStrategy {
 
-    private static String JPA_PACKAGE = "org.depromeet.spot.jpa";
-    private static String P6SPY_PACKAGE = "org.depromeet.spot.jpa.config.P6spySqlFormatter";
+    private static String JPA_PACKAGE = "org.depromeet.spot";
+    private static String P6SPY_PACKAGE = "org.depromeet.spot.jpa.common.P6spySqlFormatter";
 
     @Override
     public String formatMessage(

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/config/P6spyConfig.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/config/P6spyConfig.java
@@ -1,0 +1,17 @@
+package org.depromeet.spot.jpa.config;
+
+import jakarta.annotation.PostConstruct;
+
+import org.depromeet.spot.jpa.common.P6spySqlFormatter;
+import org.springframework.context.annotation.Configuration;
+
+import com.p6spy.engine.spy.P6SpyOptions;
+
+@Configuration
+public class P6spyConfig {
+
+    @PostConstruct
+    public void setLogMessageFormat() {
+        P6SpyOptions.getActiveInstance().setLogMessageFormat(P6spySqlFormatter.class.getName());
+    }
+}

--- a/infrastructure/jpa/src/main/resources/application-jpa.yaml
+++ b/infrastructure/jpa/src/main/resources/application-jpa.yaml
@@ -17,3 +17,8 @@ spring:
     console:
       enabled: true
       path: /h2-console
+
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true

--- a/versions.properties
+++ b/versions.properties
@@ -23,3 +23,5 @@ version.org.springframework.boot..spring-boot-starter-data-jpa=3.0.1
 
 version.org.springdoc..springdoc-openapi-starter-webmvc-ui=2.5.0
 
+version.com.github.gavlyukovskiy..p6spy-spring-boot-starter=1.9.0
+


### PR DESCRIPTION
## 📌 개요 (필수)

- 내가 작성한 코드가 실제 쿼리로 어떻게 변환되는지 확인하기 위해 쿼리 로그를 추가해요.
- jpa.properties.hibernate.show_sql은 가독성이 좋지 않아서, p6spy 라이브러리를 사용했어요.

<br>

## 🔨 작업 사항 (필수)

- p6spy 의존성 추가
- 쿼리 로그 포맷터 & 설정 파일 추가

<br>

## 🌱 연관 내용 (선택)

- 공식 가이드
  - [p6spy](https://github.com/p6spy/p6spy) 
  - [p6spy-spring-boot-starter](https://github.com/gavlyukovskiy/spring-boot-data-source-decorator?tab=readme-ov-file)

p6spy는 datasource에 프록시로 붙어서 동작해요. spring-boot-starter를 이용해 보다 편리하게 사용할 수 있어요. 

<br>

## 💻 실행 화면 

- jpa.properties.hibernate.show_sql 적용 :: 가독성 안좋고 매개변수도 안보임
<img width="1156" alt="스크린샷 2024-07-04 오전 12 34 09" src="https://github.com/depromeet/SPOT-server/assets/38103085/fda66c8b-555f-40e5-9ff0-e3e86237a5c6">


- jpa.properties.hibernate.format_sql 추가 적용 :: 가독성은 좋아졌으나 여전히 매개변수 안보임
<img width="1160" alt="스크린샷 2024-07-04 오전 12 33 48" src="https://github.com/depromeet/SPOT-server/assets/38103085/87f62fe0-97b1-4194-b4fc-bf583c2ba1ea">

- show_sql, format_sql 다 지우고 p6spy만 적용 :: 가독성도 좋고 stacktrace도 보이고 실행시간도 보이고 매개변수도 보임 ^^👍
<img width="1213" alt="스크린샷 2024-07-04 오전 12 47 05" src="https://github.com/depromeet/SPOT-server/assets/38103085/1faef2ef-47f7-4d8f-8998-8ba53d05bbc2">





