### PR TITLE
[BSVR-56] QueryDSL 설정 추가

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 2
+indent_size = 4
 indent_style = space
 insert_final_newline = false
 max_line_length = 100

--- a/application/src/main/java/org/depromeet/spot/application/member/controller/MemberController.java
+++ b/application/src/main/java/org/depromeet/spot/application/member/controller/MemberController.java
@@ -1,16 +1,21 @@
 package org.depromeet.spot.application.member.controller;
 
+import java.util.List;
+
 import org.depromeet.spot.application.member.dto.request.MemberRequest;
 import org.depromeet.spot.application.member.dto.response.MemberResponse;
 import org.depromeet.spot.usecase.port.in.MemberUsecase;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
@@ -30,5 +35,15 @@ public class MemberController {
     public MemberResponse create(@RequestBody MemberRequest request) {
         val member = memberUsecase.create(request.name());
         return MemberResponse.from(member);
+    }
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "이름으로 Member 조회하는 API")
+    public List<MemberResponse> findByName(
+            @RequestParam("name") @Parameter(name = "name", description = "사용자 이름", required = true)
+                    final String name) {
+        val memberList = memberUsecase.findByName(name);
+        return memberList.stream().map(MemberResponse::from).toList();
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,11 @@ subprojects {
     }
 
     tasks.register<Exec>("makeGitHooksExecutable") {
-        commandLine("chmod", "+x", "${rootProject.rootDir}/.git/hooks/pre-commit")
+        if (System.getProperty("os.name").contains("Windows")) {
+            commandLine("attrib", "+x", "${rootProject.rootDir}/.git/hooks/pre-commit")
+        } else {
+            commandLine("chmod", "+x", "${rootProject.rootDir}/.git/hooks/pre-commit")
+        }
         dependsOn("updateGitHooks")
     }
 

--- a/infrastructure/jpa/build.gradle.kts
+++ b/infrastructure/jpa/build.gradle.kts
@@ -5,12 +5,17 @@ dependencies {
     // spring
     implementation("org.springframework.boot:spring-boot-starter-data-jpa:_")
 
+    // queryDSL
+    implementation("com.querydsl:querydsl-jpa:_:jakarta")
+    annotationProcessor("com.querydsl:querydsl-apt:_:jakarta")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+
     // p6spy
     implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:_")
 
     // h2 - DB (또는 도커) 세팅 후 사라질 예정,,
     runtimeOnly("com.h2database:h2")
-
 }
 
 tasks.bootJar { enabled = false }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/config/QueryDslConfig.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package org.depromeet.spot.jpa.config;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberCustomRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberCustomRepository.java
@@ -1,0 +1,31 @@
+package org.depromeet.spot.jpa.member.repository;
+
+import static org.depromeet.spot.jpa.member.entity.QMemberEntity.memberEntity;
+
+import java.util.List;
+
+import org.depromeet.spot.jpa.member.entity.MemberEntity;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<MemberEntity> findByName(final String name) {
+        return queryFactory.selectFrom(memberEntity).where(eqMemberName(name)).fetch();
+    }
+
+    private BooleanExpression eqMemberName(final String name) {
+        if (name == null) {
+            return null;
+        }
+        return memberEntity.name.eq(name);
+    }
+}

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberRepositoryImpl.java
@@ -1,5 +1,7 @@
 package org.depromeet.spot.jpa.member.repository;
 
+import java.util.List;
+
 import org.depromeet.spot.domain.member.Member;
 import org.depromeet.spot.jpa.member.entity.MemberEntity;
 import org.depromeet.spot.usecase.port.out.MemberRepository;
@@ -13,10 +15,17 @@ import lombok.val;
 public class MemberRepositoryImpl implements MemberRepository {
 
     private final MemberJpaRepository memberJpaRepository;
+    private final MemberCustomRepository memberCustomRepository;
 
     @Override
     public Member save(Member member) {
         val memberEntity = memberJpaRepository.save(MemberEntity.from(member));
         return memberEntity.toDomain();
+    }
+
+    @Override
+    public List<Member> findByName(String name) {
+        val memberEntities = memberCustomRepository.findByName(name);
+        return memberEntities.stream().map(MemberEntity::toDomain).toList();
     }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/MemberUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/MemberUsecase.java
@@ -1,8 +1,12 @@
 package org.depromeet.spot.usecase.port.in;
 
+import java.util.List;
+
 import org.depromeet.spot.domain.member.Member;
 
 public interface MemberUsecase {
 
     Member create(String name);
+
+    List<Member> findByName(String name);
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/MemberRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/MemberRepository.java
@@ -1,8 +1,12 @@
 package org.depromeet.spot.usecase.port.out;
 
+import java.util.List;
+
 import org.depromeet.spot.domain.member.Member;
 
 public interface MemberRepository {
 
     Member save(Member member);
+
+    List<Member> findByName(String name);
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/MemberService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/MemberService.java
@@ -1,5 +1,7 @@
 package org.depromeet.spot.usecase.service;
 
+import java.util.List;
+
 import org.depromeet.spot.domain.member.Member;
 import org.depromeet.spot.usecase.port.in.MemberUsecase;
 import org.depromeet.spot.usecase.port.out.MemberRepository;
@@ -18,5 +20,10 @@ public class MemberService implements MemberUsecase {
     public Member create(final String name) {
         val member = new Member(null, name);
         return memberRepository.save(member);
+    }
+
+    @Override
+    public List<Member> findByName(final String name) {
+        return memberRepository.findByName(name);
     }
 }

--- a/versions.properties
+++ b/versions.properties
@@ -25,3 +25,7 @@ version.org.springdoc..springdoc-openapi-starter-webmvc-ui=2.5.0
 
 version.com.github.gavlyukovskiy..p6spy-spring-boot-starter=1.9.0
 
+version.com.querydsl..querydsl-apt=5.0.0
+
+version.com.querydsl..querydsl-jpa=5.0.0
+


### PR DESCRIPTION
## 📌 개요 (필수)

- 복잡한 쿼리 & 동적 쿼리 컨트롤을 위해 queryDSL 의존성을 추가해요.

<br>

## 🔨 작업 사항 (필수)

- queryDSL 의존성, 설정파일 추가
- 샘플 코드 추가
- editorconfig 인덴트 사이즈 조정
  - spotless에서 javaFormat.aosp를 사용 중이라 editorconfig랑 안맞는 이슈
    - 그냥 javaFormat은 인덴트2인데, aosp는 인덴트4
  - 티켓 파긴 작은 이슈라서 여기 PR에서 같이 고쳤어용

<br>


## 🌱 연관 내용 (선택)

- [JPAQueryFactory를 이용해 상속/구현 없이 queryDSL 사용하기](https://jojoldu.tistory.com/372)


<br>

## 💻 실행 화면

p6spy도 잘 동작하는 것 확인 완료!

<img width="1075" alt="스크린샷 2024-07-05 오전 12 13 30" src="https://github.com/depromeet/SPOT-server/assets/38103085/3f57f376-e2a4-4294-a7dd-3f088ff63909">
<img width="1241" alt="스크린샷 2024-07-05 오전 12 13 44" src="https://github.com/depromeet/SPOT-server/assets/38103085/d1ce9b6f-94eb-4baf-b6f5-7ab8bb124d38">

