### PR TITLE
[BSVR-92] 경기장 조회 API들 

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/common/dto/RgbCodeResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/dto/RgbCodeResponse.java
@@ -1,0 +1,13 @@
+package org.depromeet.spot.application.common.dto;
+
+import org.depromeet.spot.domain.common.RgbCode;
+
+import lombok.Builder;
+
+@Builder
+public record RgbCodeResponse(Integer red, Integer green, Integer blue) {
+
+    public static RgbCodeResponse from(RgbCode rgbCode) {
+        return new RgbCodeResponse(rgbCode.getRed(), rgbCode.getGreen(), rgbCode.getBlue());
+    }
+}

--- a/application/src/main/java/org/depromeet/spot/application/stadium/StadiumReadController.java
+++ b/application/src/main/java/org/depromeet/spot/application/stadium/StadiumReadController.java
@@ -1,0 +1,65 @@
+package org.depromeet.spot.application.stadium;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import org.depromeet.spot.application.stadium.dto.response.StadiumHomeTeamInfoResponse;
+import org.depromeet.spot.application.stadium.dto.response.StadiumInfoWithSeatChartResponse;
+import org.depromeet.spot.application.stadium.dto.response.StadiumNameInfoResponse;
+import org.depromeet.spot.usecase.port.in.stadium.StadiumReadUsecase;
+import org.depromeet.spot.usecase.port.in.stadium.StadiumReadUsecase.StadiumHomeTeamInfo;
+import org.depromeet.spot.usecase.port.in.stadium.StadiumReadUsecase.StadiumInfoWithSeatChart;
+import org.depromeet.spot.usecase.port.in.stadium.StadiumReadUsecase.StadiumNameInfo;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@Tag(name = "경기장")
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/stadiums")
+public class StadiumReadController {
+
+    private final StadiumReadUsecase stadiumReadUsecase;
+
+    @GetMapping()
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "SPOT에서 관리하는 모든 야구 경기장 정보를 조회한다.")
+    public List<StadiumHomeTeamInfoResponse> findAllStadiums() {
+        List<StadiumHomeTeamInfo> infos = stadiumReadUsecase.findAllStadiums();
+        return infos.stream().map(StadiumHomeTeamInfoResponse::from).toList();
+    }
+
+    @GetMapping("/names")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "SPOT에서 관리하는 모든 야구 경기장의 이름들을 조회한다.")
+    public List<StadiumNameInfoResponse> findAllNames() {
+        List<StadiumNameInfo> infos = stadiumReadUsecase.findAllNames();
+        return infos.stream()
+                .map(t -> new StadiumNameInfoResponse(t.getId(), t.getName()))
+                .toList();
+    }
+
+    @GetMapping("/{stadiumId}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "특정 야구 경기장의 상세 정보를 좌석 배치도와 함께 조회한다.")
+    public StadiumInfoWithSeatChartResponse findWithSeatChartById(
+            @PathVariable("stadiumId")
+                    @NotNull
+                    @Positive
+                    @Parameter(name = "stadiumId", description = "야구 경기장 PK", required = true)
+                    final Long stadiumId) {
+        StadiumInfoWithSeatChart info = stadiumReadUsecase.findWithSeatChartById(stadiumId);
+        return StadiumInfoWithSeatChartResponse.from(info);
+    }
+}

--- a/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/HomeTeamInfoResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/HomeTeamInfoResponse.java
@@ -1,0 +1,20 @@
+package org.depromeet.spot.application.stadium.dto.response;
+
+import org.depromeet.spot.application.common.dto.RgbCodeResponse;
+import org.depromeet.spot.domain.common.RgbCode;
+import org.depromeet.spot.usecase.port.in.team.StadiumHomeTeamReadUsecase.HomeTeamInfo;
+
+public record HomeTeamInfoResponse(Long id, String alias, RgbCodeResponse color) {
+
+    public static HomeTeamInfoResponse from(HomeTeamInfo homeTeamInfo) {
+        RgbCode rgbCode = homeTeamInfo.getRgbCode();
+        RgbCodeResponse rgbCodeRes =
+                RgbCodeResponse.builder()
+                        .red(rgbCode.getRed())
+                        .blue(rgbCode.getBlue())
+                        .green(rgbCode.getGreen())
+                        .build();
+
+        return new HomeTeamInfoResponse(homeTeamInfo.getId(), homeTeamInfo.getAlias(), rgbCodeRes);
+    }
+}

--- a/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumHomeTeamInfoResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumHomeTeamInfoResponse.java
@@ -1,0 +1,31 @@
+package org.depromeet.spot.application.stadium.dto.response;
+
+import java.util.List;
+
+import org.depromeet.spot.usecase.port.in.stadium.StadiumReadUsecase.StadiumHomeTeamInfo;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public record StadiumHomeTeamInfoResponse(
+        Long id,
+        String name,
+        String thumbnail,
+        List<HomeTeamInfoResponse> homeTeams,
+        boolean isActive) {
+    public static StadiumHomeTeamInfoResponse from(StadiumHomeTeamInfo stadiumHomeTeamInfo) {
+        List<HomeTeamInfoResponse> homeTeams =
+                stadiumHomeTeamInfo.getHomeTeams().stream()
+                        .map(HomeTeamInfoResponse::from)
+                        .toList();
+
+        return new StadiumHomeTeamInfoResponse(
+                stadiumHomeTeamInfo.getId(),
+                stadiumHomeTeamInfo.getName(),
+                stadiumHomeTeamInfo.getThumbnail(),
+                homeTeams,
+                stadiumHomeTeamInfo.isActive());
+    }
+}

--- a/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumHomeTeamInfoResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumHomeTeamInfoResponse.java
@@ -5,9 +5,7 @@ import java.util.List;
 import org.depromeet.spot.usecase.port.in.stadium.StadiumReadUsecase.StadiumHomeTeamInfo;
 
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
 @Builder
 public record StadiumHomeTeamInfoResponse(
         Long id,

--- a/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumInfoWithSeatChartResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumInfoWithSeatChartResponse.java
@@ -1,0 +1,26 @@
+package org.depromeet.spot.application.stadium.dto.response;
+
+import java.util.List;
+
+import org.depromeet.spot.usecase.port.in.stadium.StadiumReadUsecase.StadiumInfoWithSeatChart;
+
+import lombok.Builder;
+
+@Builder
+public record StadiumInfoWithSeatChartResponse(
+        Long id, String name, String seatChartWithLabel, List<HomeTeamInfoResponse> homeTeams) {
+
+    public static StadiumInfoWithSeatChartResponse from(
+            StadiumInfoWithSeatChart stadiumInfoWithSeatChart) {
+        List<HomeTeamInfoResponse> homeTeams =
+                stadiumInfoWithSeatChart.getHomeTeams().stream()
+                        .map(HomeTeamInfoResponse::from)
+                        .toList();
+
+        return new StadiumInfoWithSeatChartResponse(
+                stadiumInfoWithSeatChart.getId(),
+                stadiumInfoWithSeatChart.getName(),
+                stadiumInfoWithSeatChart.getSeatChartWithLabel(),
+                homeTeams);
+    }
+}

--- a/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumNameInfoResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumNameInfoResponse.java
@@ -1,0 +1,3 @@
+package org.depromeet.spot.application.stadium.dto.response;
+
+public record StadiumNameInfoResponse(Long id, String name) {}

--- a/common/src/main/java/org/depromeet/spot/common/exception/stadium/StadiumErrorCode.java
+++ b/common/src/main/java/org/depromeet/spot/common/exception/stadium/StadiumErrorCode.java
@@ -1,0 +1,27 @@
+package org.depromeet.spot.common.exception.stadium;
+
+import org.depromeet.spot.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public enum StadiumErrorCode implements ErrorCode {
+    STADIUM_NOT_FOUND(HttpStatus.NOT_FOUND, "ST001", "요청 경기장이 존재하지 않습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private String message;
+
+    StadiumErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    public StadiumErrorCode appended(Object o) {
+        message = message + " {" + o.toString() + "}";
+        return this;
+    }
+}

--- a/common/src/main/java/org/depromeet/spot/common/exception/stadium/StadiumException.java
+++ b/common/src/main/java/org/depromeet/spot/common/exception/stadium/StadiumException.java
@@ -1,0 +1,20 @@
+package org.depromeet.spot.common.exception.stadium;
+
+import org.depromeet.spot.common.exception.BusinessException;
+
+public abstract class StadiumException extends BusinessException {
+
+    protected StadiumException(StadiumErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public static class StadiumNotFoundException extends StadiumException {
+        public StadiumNotFoundException() {
+            super(StadiumErrorCode.STADIUM_NOT_FOUND);
+        }
+
+        public StadiumNotFoundException(String str) {
+            super(StadiumErrorCode.STADIUM_NOT_FOUND.appended(str));
+        }
+    }
+}

--- a/common/src/main/java/org/depromeet/spot/common/exception/util/UtilErrorCode.java
+++ b/common/src/main/java/org/depromeet/spot/common/exception/util/UtilErrorCode.java
@@ -1,0 +1,27 @@
+package org.depromeet.spot.common.exception.util;
+
+import org.depromeet.spot.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public enum UtilErrorCode implements ErrorCode {
+    INVALID_RGB_CODE(HttpStatus.BAD_REQUEST, "UT001", "잘못된 RGB 코드 값 입니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private String message;
+
+    UtilErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    public UtilErrorCode appended(Object o) {
+        message = message + " {" + o.toString() + "}";
+        return this;
+    }
+}

--- a/common/src/main/java/org/depromeet/spot/common/exception/util/UtilException.java
+++ b/common/src/main/java/org/depromeet/spot/common/exception/util/UtilException.java
@@ -1,0 +1,15 @@
+package org.depromeet.spot.common.exception.util;
+
+import org.depromeet.spot.common.exception.BusinessException;
+
+public abstract class UtilException extends BusinessException {
+    protected UtilException(UtilErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public static class InvalidRgbCodeException extends UtilException {
+        public InvalidRgbCodeException() {
+            super(UtilErrorCode.INVALID_RGB_CODE);
+        }
+    }
+}

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
+    implementation(project(":common"))
 }
 
 tasks.jar { enabled = true }

--- a/domain/src/main/java/org/depromeet/spot/domain/common/RgbCode.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/common/RgbCode.java
@@ -1,0 +1,25 @@
+package org.depromeet.spot.domain.common;
+
+import lombok.Getter;
+
+@Getter
+public class RgbCode {
+
+    private final Integer red;
+    private final Integer green;
+    private final Integer blue;
+
+    public RgbCode(Integer red, Integer green, Integer blue) {
+        isValidRgb(red, green, blue);
+        this.red = red;
+        this.green = green;
+        this.blue = blue;
+    }
+
+    private static void isValidRgb(Integer red, Integer green, Integer blue) {
+        if (red == null || green == null || blue == null) {
+            // FIXME: custom exception 대체
+            throw new IllegalArgumentException();
+        }
+    }
+}

--- a/domain/src/main/java/org/depromeet/spot/domain/common/RgbCode.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/common/RgbCode.java
@@ -1,5 +1,7 @@
 package org.depromeet.spot.domain.common;
 
+import org.depromeet.spot.common.exception.util.UtilException.InvalidRgbCodeException;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -20,8 +22,7 @@ public class RgbCode {
 
     private static void isValidRgb(Integer red, Integer green, Integer blue) {
         if (red == null || green == null || blue == null) {
-            // FIXME: custom exception 대체
-            throw new IllegalArgumentException();
+            throw new InvalidRgbCodeException();
         }
     }
 }

--- a/domain/src/main/java/org/depromeet/spot/domain/common/RgbCode.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/common/RgbCode.java
@@ -1,8 +1,10 @@
 package org.depromeet.spot.domain.common;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class RgbCode {
 
     private final Integer red;

--- a/domain/src/main/java/org/depromeet/spot/domain/section/Section.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/section/Section.java
@@ -1,32 +1,23 @@
 package org.depromeet.spot.domain.section;
 
+import org.depromeet.spot.domain.common.RgbCode;
+
 import lombok.Getter;
 
 @Getter
 public class Section {
 
-    public final Long id;
-    public final Long stadiumId;
-    public final String name;
-    public final String alias;
-    public final Integer red;
-    public final Integer green;
-    public final Integer blue;
+    private final Long id;
+    private final Long stadiumId;
+    private final String name;
+    private final String alias;
+    private final RgbCode labelRgbCode;
 
-    public Section(
-            Long id,
-            Long stadiumId,
-            String name,
-            String alias,
-            Integer red,
-            Integer green,
-            Integer blue) {
+    public Section(Long id, Long stadiumId, String name, String alias, RgbCode labelRgbCode) {
         this.id = id;
         this.stadiumId = stadiumId;
         this.name = name;
         this.alias = alias;
-        this.red = red;
-        this.green = green;
-        this.blue = blue;
+        this.labelRgbCode = labelRgbCode;
     }
 }

--- a/domain/src/main/java/org/depromeet/spot/domain/stadium/Stadium.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/stadium/Stadium.java
@@ -1,26 +1,18 @@
 package org.depromeet.spot.domain.stadium;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
+@AllArgsConstructor
 public class Stadium {
 
-    public final Long id;
-    public final String name;
-    public final String mainImage;
-    public final String seatingChartImage;
-    public final String labeledSeatingChartImage;
-
-    public Stadium(
-            Long id,
-            String name,
-            String mainImage,
-            String seatingChartImage,
-            String labeledSeatingChartImage) {
-        this.id = id;
-        this.name = name;
-        this.mainImage = mainImage;
-        this.seatingChartImage = seatingChartImage;
-        this.labeledSeatingChartImage = labeledSeatingChartImage;
-    }
+    private final Long id;
+    private final String name;
+    private final String mainImage;
+    private final String seatingChartImage;
+    private final String labeledSeatingChartImage;
+    private final boolean isActive;
 }

--- a/domain/src/main/java/org/depromeet/spot/domain/team/BaseballTeam.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/team/BaseballTeam.java
@@ -1,32 +1,23 @@
 package org.depromeet.spot.domain.team;
 
+import org.depromeet.spot.domain.common.RgbCode;
+
 import lombok.Getter;
 
 @Getter
 public class BaseballTeam {
 
-    public final Long id;
-    public final String name;
-    public final String alias;
-    public final String logo;
-    public final Integer red;
-    public final Integer green;
-    public final Integer blue;
+    private final Long id;
+    private final String name;
+    private final String alias;
+    private final String logo;
+    private final RgbCode labelRgbCode;
 
-    public BaseballTeam(
-            Long id,
-            String name,
-            String alias,
-            String logo,
-            Integer red,
-            Integer green,
-            Integer blue) {
+    public BaseballTeam(Long id, String name, String alias, String logo, RgbCode labelRgbCode) {
         this.id = id;
         this.name = name;
         this.alias = alias;
         this.logo = logo;
-        this.red = red;
-        this.green = green;
-        this.blue = blue;
+        this.labelRgbCode = labelRgbCode;
     }
 }

--- a/domain/src/main/java/org/depromeet/spot/domain/team/StadiumHomeTeam.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/team/StadiumHomeTeam.java
@@ -1,7 +1,5 @@
 package org.depromeet.spot.domain.team;
 
-import org.depromeet.spot.domain.stadium.Stadium;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,6 +8,6 @@ import lombok.Getter;
 public class StadiumHomeTeam {
 
     private final Long id;
-    private final Stadium stadium;
-    private final BaseballTeam baseballTeam;
+    private final Long stadiumId;
+    private final Long teamId;
 }

--- a/domain/src/main/java/org/depromeet/spot/domain/team/StadiumHomeTeam.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/team/StadiumHomeTeam.java
@@ -1,17 +1,15 @@
 package org.depromeet.spot.domain.team;
 
+import org.depromeet.spot.domain.stadium.Stadium;
+
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class StadiumHomeTeam {
 
     private final Long id;
-    private final Long stadiumId;
-    private final Long teamId;
-
-    public StadiumHomeTeam(Long id, Long stadiumId, Long teamId) {
-        this.id = id;
-        this.stadiumId = stadiumId;
-        this.teamId = teamId;
-    }
+    private final Stadium stadium;
+    private final BaseballTeam baseballTeam;
 }

--- a/infrastructure/jpa/build.gradle.kts
+++ b/infrastructure/jpa/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
+    implementation(project(":common"))
     implementation(project(":domain"))
     implementation(project(":usecase"))
 

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/config/QueryDslConfig.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/config/QueryDslConfig.java
@@ -6,6 +6,7 @@ import jakarta.persistence.PersistenceContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 @Configuration
@@ -15,6 +16,6 @@ public class QueryDslConfig {
 
     @Bean
     public JPAQueryFactory queryFactory() {
-        return new JPAQueryFactory(entityManager);
+        return new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/section/entity/SectionEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/section/entity/SectionEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import org.depromeet.spot.domain.common.RgbCode;
 import org.depromeet.spot.domain.section.Section;
 
 import lombok.NoArgsConstructor;
@@ -56,17 +57,19 @@ public class SectionEntity {
     }
 
     public static SectionEntity from(Section section) {
+        RgbCode labelRgbCode = section.getLabelRgbCode();
         return new SectionEntity(
                 section.getId(),
                 section.getStadiumId(),
                 section.getName(),
                 section.getAlias(),
-                section.getRed(),
-                section.getGreen(),
-                section.getBlue());
+                labelRgbCode.getRed(),
+                labelRgbCode.getGreen(),
+                labelRgbCode.getBlue());
     }
 
     public Section toDomain() {
-        return new Section(id, stadiumId, name, alias, red, green, blue);
+        RgbCode rgbCode = RgbCode.builder().red(red).green(green).blue(blue).build();
+        return new Section(id, stadiumId, name, alias, rgbCode);
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/stadium/entity/StadiumEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/stadium/entity/StadiumEntity.java
@@ -32,17 +32,22 @@ public class StadiumEntity {
     @Column(name = "labeled_seating_chart_image", length = 255)
     private String labeledSeatingChartImage;
 
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive;
+
     public StadiumEntity(
             Long id,
             String name,
             String mainImage,
             String seatingChartImage,
-            String labeledSeatingChartImage) {
+            String labeledSeatingChartImage,
+            boolean isActive) {
         this.id = id;
         this.name = name;
         this.mainImage = mainImage;
         this.seatingChartImage = seatingChartImage;
         this.labeledSeatingChartImage = labeledSeatingChartImage;
+        this.isActive = isActive;
     }
 
     public static StadiumEntity from(Stadium stadium) {
@@ -51,10 +56,18 @@ public class StadiumEntity {
                 stadium.getName(),
                 stadium.getMainImage(),
                 stadium.getSeatingChartImage(),
-                stadium.getLabeledSeatingChartImage());
+                stadium.getLabeledSeatingChartImage(),
+                stadium.isActive());
     }
 
     public Stadium toDomain() {
-        return new Stadium(id, name, mainImage, seatingChartImage, labeledSeatingChartImage);
+        return Stadium.builder()
+                .id(id)
+                .name(name)
+                .mainImage(mainImage)
+                .seatingChartImage(seatingChartImage)
+                .labeledSeatingChartImage(labeledSeatingChartImage)
+                .isActive(isActive)
+                .build();
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/stadium/repository/StadiumJpaRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/stadium/repository/StadiumJpaRepository.java
@@ -1,0 +1,6 @@
+package org.depromeet.spot.jpa.stadium.repository;
+
+import org.depromeet.spot.jpa.stadium.entity.StadiumEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StadiumJpaRepository extends JpaRepository<StadiumEntity, Long> {}

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/stadium/repository/StadiumRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/stadium/repository/StadiumRepositoryImpl.java
@@ -1,0 +1,31 @@
+package org.depromeet.spot.jpa.stadium.repository;
+
+import java.util.List;
+
+import org.depromeet.spot.domain.stadium.Stadium;
+import org.depromeet.spot.jpa.stadium.entity.StadiumEntity;
+import org.depromeet.spot.usecase.port.out.stadium.StadiumRepository;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class StadiumRepositoryImpl implements StadiumRepository {
+
+    private final StadiumJpaRepository stadiumJpaRepository;
+
+    @Override
+    public Stadium findById(final Long id) {
+        // FIXME: custom exception 추가
+        StadiumEntity entity =
+                stadiumJpaRepository.findById(id).orElseThrow(IllegalArgumentException::new);
+        return entity.toDomain();
+    }
+
+    @Override
+    public List<Stadium> findAll() {
+        List<StadiumEntity> entities = stadiumJpaRepository.findAll();
+        return entities.stream().map(StadiumEntity::toDomain).toList();
+    }
+}

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/stadium/repository/StadiumRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/stadium/repository/StadiumRepositoryImpl.java
@@ -2,6 +2,7 @@ package org.depromeet.spot.jpa.stadium.repository;
 
 import java.util.List;
 
+import org.depromeet.spot.common.exception.stadium.StadiumException.StadiumNotFoundException;
 import org.depromeet.spot.domain.stadium.Stadium;
 import org.depromeet.spot.jpa.stadium.entity.StadiumEntity;
 import org.depromeet.spot.usecase.port.out.stadium.StadiumRepository;
@@ -17,10 +18,10 @@ public class StadiumRepositoryImpl implements StadiumRepository {
 
     @Override
     public Stadium findById(final Long id) {
-        // FIXME: custom exception 추가
-        StadiumEntity entity =
-                stadiumJpaRepository.findById(id).orElseThrow(IllegalArgumentException::new);
-        return entity.toDomain();
+        return stadiumJpaRepository
+                .findById(id)
+                .orElseThrow(() -> new StadiumNotFoundException(id + "의 경기장은 존재하지 않습니다."))
+                .toDomain();
     }
 
     @Override

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/team/entity/BaseballTeamEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/team/entity/BaseballTeamEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import org.depromeet.spot.domain.common.RgbCode;
 import org.depromeet.spot.domain.team.BaseballTeam;
 
 import lombok.NoArgsConstructor;
@@ -56,17 +57,19 @@ public class BaseballTeamEntity {
     }
 
     public static BaseballTeamEntity from(BaseballTeam baseballTeam) {
+        RgbCode labelRgbCode = baseballTeam.getLabelRgbCode();
         return new BaseballTeamEntity(
                 baseballTeam.getId(),
                 baseballTeam.getName(),
                 baseballTeam.getAlias(),
                 baseballTeam.getLogo(),
-                baseballTeam.getRed(),
-                baseballTeam.getGreen(),
-                baseballTeam.getBlue());
+                labelRgbCode.getRed(),
+                labelRgbCode.getGreen(),
+                labelRgbCode.getBlue());
     }
 
     public BaseballTeam toDomain() {
-        return new BaseballTeam(id, name, alias, logo, red, green, blue);
+        RgbCode labelRgbCode = RgbCode.builder().red(red).green(green).blue(blue).build();
+        return new BaseballTeam(id, name, alias, logo, labelRgbCode);
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/team/repository/BaseballTeamRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/team/repository/BaseballTeamRepositoryImpl.java
@@ -1,0 +1,24 @@
+package org.depromeet.spot.jpa.team.repository;
+
+import java.util.List;
+
+import org.depromeet.spot.domain.team.BaseballTeam;
+import org.depromeet.spot.jpa.team.entity.BaseballTeamEntity;
+import org.depromeet.spot.usecase.port.out.team.BaseballTeamRepository;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BaseballTeamRepositoryImpl implements BaseballTeamRepository {
+
+    private final StadiumHomeTeamCustomRepository stadiumHomeTeamCustomRepository;
+
+    @Override
+    public List<BaseballTeam> findAllHomeTeamByStadium(final Long stadiumId) {
+        List<BaseballTeamEntity> homeTeamEntities =
+                stadiumHomeTeamCustomRepository.findAllHomeTeamByStadium(stadiumId);
+        return homeTeamEntities.stream().map(BaseballTeamEntity::toDomain).toList();
+    }
+}

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/team/repository/BaseballTeamRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/team/repository/BaseballTeamRepositoryImpl.java
@@ -1,8 +1,12 @@
 package org.depromeet.spot.jpa.team.repository;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import org.depromeet.spot.domain.stadium.Stadium;
 import org.depromeet.spot.domain.team.BaseballTeam;
+import org.depromeet.spot.jpa.stadium.entity.StadiumEntity;
 import org.depromeet.spot.jpa.team.entity.BaseballTeamEntity;
 import org.depromeet.spot.usecase.port.out.team.BaseballTeamRepository;
 import org.springframework.stereotype.Repository;
@@ -20,5 +24,19 @@ public class BaseballTeamRepositoryImpl implements BaseballTeamRepository {
         List<BaseballTeamEntity> homeTeamEntities =
                 stadiumHomeTeamCustomRepository.findAllHomeTeamByStadium(stadiumId);
         return homeTeamEntities.stream().map(BaseballTeamEntity::toDomain).toList();
+    }
+
+    @Override
+    public Map<Stadium, List<BaseballTeam>> findAllStadiumHomeTeam() {
+        Map<StadiumEntity, List<BaseballTeamEntity>> stadiumHomeTeamMap =
+                stadiumHomeTeamCustomRepository.findAllStadiumHomeTeam();
+        return stadiumHomeTeamMap.entrySet().stream()
+                .collect(
+                        Collectors.toMap(
+                                entry -> entry.getKey().toDomain(),
+                                entry ->
+                                        entry.getValue().stream()
+                                                .map(BaseballTeamEntity::toDomain)
+                                                .toList()));
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/team/repository/StadiumHomeTeamCustomRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/team/repository/StadiumHomeTeamCustomRepository.java
@@ -1,10 +1,15 @@
 package org.depromeet.spot.jpa.team.repository;
 
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
+import static org.depromeet.spot.jpa.stadium.entity.QStadiumEntity.stadiumEntity;
 import static org.depromeet.spot.jpa.team.entity.QBaseballTeamEntity.baseballTeamEntity;
 import static org.depromeet.spot.jpa.team.entity.QStadiumHomeTeamEntity.stadiumHomeTeamEntity;
 
 import java.util.List;
+import java.util.Map;
 
+import org.depromeet.spot.jpa.stadium.entity.StadiumEntity;
 import org.depromeet.spot.jpa.team.entity.BaseballTeamEntity;
 import org.springframework.stereotype.Repository;
 
@@ -26,5 +31,15 @@ public class StadiumHomeTeamCustomRepository {
                 .on(stadiumHomeTeamEntity.teamId.eq(baseballTeamEntity.id))
                 .where(stadiumHomeTeamEntity.stadiumId.eq(stadiumId))
                 .fetch();
+    }
+
+    public Map<StadiumEntity, List<BaseballTeamEntity>> findAllStadiumHomeTeam() {
+        return queryFactory
+                .from(stadiumHomeTeamEntity)
+                .join(stadiumEntity)
+                .on(stadiumHomeTeamEntity.stadiumId.eq(stadiumEntity.id))
+                .join(baseballTeamEntity)
+                .on(stadiumHomeTeamEntity.teamId.eq(baseballTeamEntity.id))
+                .transform(groupBy(stadiumEntity).as(list(baseballTeamEntity)));
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/team/repository/StadiumHomeTeamCustomRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/team/repository/StadiumHomeTeamCustomRepository.java
@@ -1,0 +1,30 @@
+package org.depromeet.spot.jpa.team.repository;
+
+import static org.depromeet.spot.jpa.team.entity.QBaseballTeamEntity.baseballTeamEntity;
+import static org.depromeet.spot.jpa.team.entity.QStadiumHomeTeamEntity.stadiumHomeTeamEntity;
+
+import java.util.List;
+
+import org.depromeet.spot.jpa.team.entity.BaseballTeamEntity;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class StadiumHomeTeamCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<BaseballTeamEntity> findAllHomeTeamByStadium(final Long stadiumId) {
+        return queryFactory
+                .select(baseballTeamEntity)
+                .from(stadiumHomeTeamEntity)
+                .join(baseballTeamEntity)
+                .on(stadiumHomeTeamEntity.teamId.eq(baseballTeamEntity.id))
+                .where(stadiumHomeTeamEntity.stadiumId.eq(stadiumId))
+                .fetch();
+    }
+}

--- a/infrastructure/jpa/src/main/resources/application-jpa.yaml
+++ b/infrastructure/jpa/src/main/resources/application-jpa.yaml
@@ -10,11 +10,10 @@ spring:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
       ddl-auto: update  # 주의: 프로덕션 환경에서는 'validate' 사용 권장
-    show-sql: true
     properties:
       hibernate:
-        format_sql: true
         use_sql_comments: true
+    defer-datasource-initialization: true
 
   sql:
     init:

--- a/infrastructure/jpa/src/main/resources/data.sql
+++ b/infrastructure/jpa/src/main/resources/data.sql
@@ -1,0 +1,18 @@
+-- Stadiums
+INSERT INTO stadiums (id, name, main_image, seating_chart_image, labeled_seating_chart_image, is_active)
+VALUES (1, '잠실 야구 경기장', 'main_image_a.jpg', 'seating_chart_a.jpg', 'labeled_seating_chart_a.jpg', true),
+       (2, '김포 야구 경기장', 'main_image_b.jpg', 'seating_chart_b.jpg', 'labeled_seating_chart_b.jpg', true),
+       (3, '부산 야구 경기장', 'main_image_c.jpg', 'seating_chart_c.jpg', 'labeled_seating_chart_c.jpg', false);
+
+-- Baseball Teams
+INSERT INTO baseball_teams (id, name, alias, logo, red, green, blue)
+VALUES (1, 'Team A', 'A', 'logo_a.png', 255, 0, 0),
+       (2, 'Team B', 'B', 'logo_b.png', 0, 255, 0),
+       (3, 'Team C', 'C', 'logo_c.png', 0, 0, 255);
+
+-- Stadium Home Teams
+INSERT INTO stadium_home_teams (id, stadium_id, team_id)
+VALUES (1, 1, 1),
+       (2, 2, 2),
+       (3, 3, 3),
+       (4, 1, 2);

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/StadiumReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/StadiumReadUsecase.java
@@ -1,3 +1,0 @@
-package org.depromeet.spot.usecase.port.in;
-
-public interface StadiumReadUsecase {}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/StadiumReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/StadiumReadUsecase.java
@@ -1,0 +1,3 @@
+package org.depromeet.spot.usecase.port.in;
+
+public interface StadiumReadUsecase {}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/StadiumReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/StadiumReadUsecase.java
@@ -1,0 +1,43 @@
+package org.depromeet.spot.usecase.port.in.stadium;
+
+import java.util.List;
+
+import org.depromeet.spot.usecase.port.in.team.StadiumHomeTeamReadUsecase.HomeTeamInfo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public interface StadiumReadUsecase {
+
+    List<StadiumHomeTeamInfo> findAllStadiums();
+
+    List<StadiumNameInfo> findAllName();
+
+    StadiumInfoWithSeatChart findWithSeatChartById(Long id);
+
+    @Getter
+    @AllArgsConstructor
+    class StadiumHomeTeamInfo {
+        private final Long id;
+        private final String name;
+        private final List<HomeTeamInfo> homeTeams;
+        private final String thumbnail;
+        private final boolean isActive;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    class StadiumInfoWithSeatChart {
+        private final Long id;
+        private final String name;
+        private final List<HomeTeamInfo> homeTeams;
+        private final String seatChartWithLabel;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    class StadiumNameInfo {
+        private final Long id;
+        private final String name;
+    }
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/StadiumReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/StadiumReadUsecase.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.depromeet.spot.usecase.port.in.team.StadiumHomeTeamReadUsecase.HomeTeamInfo;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 public interface StadiumReadUsecase {
@@ -26,6 +27,7 @@ public interface StadiumReadUsecase {
     }
 
     @Getter
+    @Builder
     @AllArgsConstructor
     class StadiumInfoWithSeatChart {
         private final Long id;

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/StadiumReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/StadiumReadUsecase.java
@@ -11,7 +11,7 @@ public interface StadiumReadUsecase {
 
     List<StadiumHomeTeamInfo> findAllStadiums();
 
-    List<StadiumNameInfo> findAllName();
+    List<StadiumNameInfo> findAllNames();
 
     StadiumInfoWithSeatChart findWithSeatChartById(Long id);
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/team/StadiumHomeTeamReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/team/StadiumHomeTeamReadUsecase.java
@@ -1,8 +1,11 @@
 package org.depromeet.spot.usecase.port.in.team;
 
 import java.util.List;
+import java.util.Map;
 
 import org.depromeet.spot.domain.common.RgbCode;
+import org.depromeet.spot.domain.stadium.Stadium;
+import org.depromeet.spot.domain.team.BaseballTeam;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,6 +13,8 @@ import lombok.Getter;
 public interface StadiumHomeTeamReadUsecase {
 
     List<HomeTeamInfo> findByStadium(Long stadiumId);
+
+    Map<Stadium, List<BaseballTeam>> findAllStadiumHomeTeam();
 
     @Getter
     @AllArgsConstructor

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/team/StadiumHomeTeamReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/team/StadiumHomeTeamReadUsecase.java
@@ -1,0 +1,17 @@
+package org.depromeet.spot.usecase.port.in.team;
+
+import org.depromeet.spot.domain.common.RgbCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public interface StadiumHomeTeamReadUsecase {
+
+    @Getter
+    @AllArgsConstructor
+    class HomeTeamInfo {
+        private final Long id;
+        private final String alias;
+        private final RgbCode rgbCode;
+    }
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/team/StadiumHomeTeamReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/team/StadiumHomeTeamReadUsecase.java
@@ -1,11 +1,15 @@
 package org.depromeet.spot.usecase.port.in.team;
 
+import java.util.List;
+
 import org.depromeet.spot.domain.common.RgbCode;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 public interface StadiumHomeTeamReadUsecase {
+
+    List<HomeTeamInfo> findByStadium(Long stadiumId);
 
     @Getter
     @AllArgsConstructor

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/stadium/StadiumRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/stadium/StadiumRepository.java
@@ -1,3 +1,11 @@
 package org.depromeet.spot.usecase.port.out.stadium;
 
-public interface StadiumRepository {}
+import java.util.List;
+
+import org.depromeet.spot.domain.stadium.Stadium;
+
+public interface StadiumRepository {
+    Stadium findById(Long id);
+
+    List<Stadium> findAll();
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/stadium/StadiumRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/stadium/StadiumRepository.java
@@ -1,0 +1,3 @@
+package org.depromeet.spot.usecase.port.out.stadium;
+
+public interface StadiumRepository {}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/team/BaseballTeamRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/team/BaseballTeamRepository.java
@@ -1,10 +1,14 @@
 package org.depromeet.spot.usecase.port.out.team;
 
 import java.util.List;
+import java.util.Map;
 
+import org.depromeet.spot.domain.stadium.Stadium;
 import org.depromeet.spot.domain.team.BaseballTeam;
 
 public interface BaseballTeamRepository {
 
     List<BaseballTeam> findAllHomeTeamByStadium(Long stadiumId);
+
+    Map<Stadium, List<BaseballTeam>> findAllStadiumHomeTeam();
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/team/BaseballTeamRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/team/BaseballTeamRepository.java
@@ -1,0 +1,10 @@
+package org.depromeet.spot.usecase.port.out.team;
+
+import java.util.List;
+
+import org.depromeet.spot.domain.team.BaseballTeam;
+
+public interface BaseballTeamRepository {
+
+    List<BaseballTeam> findAllHomeTeamByStadium(Long stadiumId);
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/StadiumReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/StadiumReadService.java
@@ -17,7 +17,7 @@ public class StadiumReadService implements StadiumReadUsecase {
     }
 
     @Override
-    public List<StadiumNameInfo> findAllName() {
+    public List<StadiumNameInfo> findAllNames() {
         return null;
     }
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/StadiumReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/StadiumReadService.java
@@ -1,0 +1,28 @@
+package org.depromeet.spot.usecase.service.stadium;
+
+import java.util.List;
+
+import org.depromeet.spot.usecase.port.in.stadium.StadiumReadUsecase;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class StadiumReadService implements StadiumReadUsecase {
+
+    @Override
+    public List<StadiumHomeTeamInfo> findAllStadiums() {
+        return null;
+    }
+
+    @Override
+    public List<StadiumNameInfo> findAllName() {
+        return null;
+    }
+
+    @Override
+    public StadiumInfoWithSeatChart findWithSeatChartById(Long id) {
+        return null;
+    }
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/StadiumReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/StadiumReadService.java
@@ -1,8 +1,15 @@
 package org.depromeet.spot.usecase.service.stadium;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import org.depromeet.spot.domain.stadium.Stadium;
+import org.depromeet.spot.domain.team.BaseballTeam;
 import org.depromeet.spot.usecase.port.in.stadium.StadiumReadUsecase;
+import org.depromeet.spot.usecase.port.in.team.StadiumHomeTeamReadUsecase;
+import org.depromeet.spot.usecase.port.in.team.StadiumHomeTeamReadUsecase.HomeTeamInfo;
+import org.depromeet.spot.usecase.port.out.stadium.StadiumRepository;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -11,18 +18,53 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class StadiumReadService implements StadiumReadUsecase {
 
+    private final StadiumHomeTeamReadUsecase stadiumHomeTeamReadUsecase;
+    private final StadiumRepository stadiumRepository;
+
     @Override
     public List<StadiumHomeTeamInfo> findAllStadiums() {
-        return null;
+        Map<Stadium, List<BaseballTeam>> stadiumHomeTeams =
+                stadiumHomeTeamReadUsecase.findAllStadiumHomeTeam();
+        return stadiumHomeTeams.entrySet().stream()
+                .map(
+                        entry -> {
+                            Stadium stadium = entry.getKey();
+                            List<BaseballTeam> teams = entry.getValue();
+                            List<HomeTeamInfo> homeTeamInfos =
+                                    teams.stream()
+                                            .map(
+                                                    t ->
+                                                            new HomeTeamInfo(
+                                                                    t.getId(),
+                                                                    t.getAlias(),
+                                                                    t.getLabelRgbCode()))
+                                            .collect(Collectors.toList());
+
+                            return new StadiumHomeTeamInfo(
+                                    stadium.getId(),
+                                    stadium.getName(),
+                                    homeTeamInfos,
+                                    stadium.getMainImage(),
+                                    stadium.isActive());
+                        })
+                .toList();
     }
 
     @Override
     public List<StadiumNameInfo> findAllNames() {
-        return null;
+        List<Stadium> stadiums = stadiumRepository.findAll();
+        return stadiums.stream().map(s -> new StadiumNameInfo(s.getId(), s.getName())).toList();
     }
 
     @Override
-    public StadiumInfoWithSeatChart findWithSeatChartById(Long id) {
-        return null;
+    public StadiumInfoWithSeatChart findWithSeatChartById(final Long id) {
+        Stadium stadium = stadiumRepository.findById(id);
+        List<HomeTeamInfo> homeTeams = stadiumHomeTeamReadUsecase.findByStadium(id);
+        return StadiumInfoWithSeatChart.builder()
+                .id(stadium.getId())
+                .name(stadium.getName())
+                .homeTeams(homeTeams)
+                .seatChartWithLabel(stadium.getLabeledSeatingChartImage())
+                .build();
     }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/team/StadiumHomeTeamReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/team/StadiumHomeTeamReadService.java
@@ -1,0 +1,25 @@
+package org.depromeet.spot.usecase.service.team;
+
+import java.util.List;
+
+import org.depromeet.spot.domain.team.BaseballTeam;
+import org.depromeet.spot.usecase.port.in.team.StadiumHomeTeamReadUsecase;
+import org.depromeet.spot.usecase.port.out.team.BaseballTeamRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class StadiumHomeTeamReadService implements StadiumHomeTeamReadUsecase {
+
+    private final BaseballTeamRepository baseballTeamRepository;
+
+    @Override
+    public List<HomeTeamInfo> findByStadium(final Long stadiumId) {
+        List<BaseballTeam> teams = baseballTeamRepository.findAllHomeTeamByStadium(stadiumId);
+        return teams.stream()
+                .map(t -> new HomeTeamInfo(t.getId(), t.getAlias(), t.getLabelRgbCode()))
+                .toList();
+    }
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/team/StadiumHomeTeamReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/team/StadiumHomeTeamReadService.java
@@ -1,7 +1,9 @@
 package org.depromeet.spot.usecase.service.team;
 
 import java.util.List;
+import java.util.Map;
 
+import org.depromeet.spot.domain.stadium.Stadium;
 import org.depromeet.spot.domain.team.BaseballTeam;
 import org.depromeet.spot.usecase.port.in.team.StadiumHomeTeamReadUsecase;
 import org.depromeet.spot.usecase.port.out.team.BaseballTeamRepository;
@@ -21,5 +23,10 @@ public class StadiumHomeTeamReadService implements StadiumHomeTeamReadUsecase {
         return teams.stream()
                 .map(t -> new HomeTeamInfo(t.getId(), t.getAlias(), t.getLabelRgbCode()))
                 .toList();
+    }
+
+    @Override
+    public Map<Stadium, List<BaseballTeam>> findAllStadiumHomeTeam() {
+        return baseballTeamRepository.findAllStadiumHomeTeam();
     }
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- 1차 MVP에 존재하는 경기장 조회 API들을 구현했어요.
- 실제 동작을 확인하려고 data.sql을 추가했어요.

<br>

## 🔨 작업 사항 (필수)

- 경기장 전체 조회 API
- 경기장 이름 리스트 조회 API
- 특정 경기장 조회 API
- 위 과정에서 필요한 repository들 (경기장, 야구팀, 홈팀)
- 야구팀, 구역 도메인에 RgbCode VO 적용
- data.sql 추가

<br>

## 🌱 연관 내용 (선택)

- spring boot 3.x부터 queryDSL의 transform를 사용하려면 JPQLTemplates.DEFAULT로 설정해야 한다고 해요. [관련 이슈](https://github.com/querydsl/querydsl/issues/3428)를 첨부할게요
- queryDSL에서 데이터 형태를 잘 변환해주는지 확인하기 위해, ddl.sql을 이용해 DB에 더미 데이터를 넣었어요.
- **테스트는 다른 PR에서 추가하려해요.**
  - 간단한 조회 로직이라 테스트가 엄청 중요하진 않을 것 같음 (맵핑이나 404 잘 처리하는지 정도?)
  - 이미 PR 사이즈가 L이라서 자르는게 좋을 것 같음 😇

<br>

## 💻 실행 화면 (필수)

- 경기장 전체 조회
<img width="719" alt="스크린샷 2024-07-13 오전 12 36 24" src="https://github.com/user-attachments/assets/fcad24fb-2d31-4f63-9f92-aab40ff340db">

- 경기장 이름 목록 조회
<img width="707" alt="스크린샷 2024-07-13 오전 12 37 17" src="https://github.com/user-attachments/assets/5ef52de9-fdce-4d51-bb61-593b2d779cfc">

- 특정 경기장 조회 (정상)
<img width="727" alt="스크린샷 2024-07-13 오전 12 37 37" src="https://github.com/user-attachments/assets/19113a59-3660-46e9-9114-dab862127276">

- 특정 경기장 조회 (에러)
<img width="716" alt="스크린샷 2024-07-13 오전 12 47 07" src="https://github.com/user-attachments/assets/f50479f8-f599-4b0b-b83d-5443b6ce5373">

