### PR TITLE
[BSVR-123] DB 컨벤션에 맞춰 BaseEntity 생성

### DIFF
--- a/domain/src/main/java/org/depromeet/spot/domain/review/Review.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/review/Review.java
@@ -1,11 +1,12 @@
 package org.depromeet.spot.domain.review;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class Review {
 
     private final Long id;
@@ -14,34 +15,9 @@ public class Review {
     private final Long seatId;
     private final Long rowId;
     private final Long seatNumber;
-    private final LocalDate date; // 시간은 미표기
+    private final LocalDateTime dateTime;
     private final String content;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
     private final String status;
-
-    public Review(
-            Long id,
-            Long userId,
-            Long blockId,
-            Long seatId,
-            Long rowId,
-            Long seatNumber,
-            LocalDate date,
-            String content,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            String status) {
-        this.id = id;
-        this.userId = userId;
-        this.blockId = blockId;
-        this.seatId = seatId;
-        this.rowId = rowId;
-        this.seatNumber = seatNumber;
-        this.date = date;
-        this.content = content;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.status = status;
-    }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/block/entity/BlockEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/block/entity/BlockEntity.java
@@ -2,23 +2,19 @@ package org.depromeet.spot.jpa.block.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.block.Block;
+import org.depromeet.spot.jpa.common.entity.BaseEntity;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "blocks")
 @NoArgsConstructor
-public class BlockEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
+@AllArgsConstructor
+public class BlockEntity extends BaseEntity {
 
     @Column(name = "stadium_id", nullable = false)
     private Long stadiumId;
@@ -32,24 +28,12 @@ public class BlockEntity {
     @Column(name = "max_rows", nullable = false)
     private Integer maxRows;
 
-    public BlockEntity(Long id, Long stadiumId, Long sectionId, String code, Integer maxRows) {
-        this.id = id;
-        this.stadiumId = stadiumId;
-        this.sectionId = sectionId;
-        this.code = code;
-        this.maxRows = maxRows;
-    }
-
     public static BlockEntity from(Block block) {
         return new BlockEntity(
-                block.getId(),
-                block.getStadiumId(),
-                block.getSectionId(),
-                block.getCode(),
-                block.getMaxRows());
+                block.getStadiumId(), block.getSectionId(), block.getCode(), block.getMaxRows());
     }
 
     public Block toDomain() {
-        return new Block(id, stadiumId, sectionId, code, maxRows);
+        return new Block(this.getId(), stadiumId, sectionId, code, maxRows);
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/block/entity/BlockRowEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/block/entity/BlockRowEntity.java
@@ -2,24 +2,19 @@ package org.depromeet.spot.jpa.block.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.block.BlockRow;
+import org.depromeet.spot.jpa.common.entity.BaseEntity;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "block_rows")
 @NoArgsConstructor
-public class BlockRowEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
-
+@AllArgsConstructor
+public class BlockRowEntity extends BaseEntity {
     @Column(name = "block_id", nullable = false)
     private Long blockId;
 
@@ -29,22 +24,12 @@ public class BlockRowEntity {
     @Column(name = "max_seats", nullable = false)
     private Long maxSeats;
 
-    public BlockRowEntity(Long id, Long blockId, Long number, Long maxSeats) {
-        this.id = id;
-        this.blockId = blockId;
-        this.number = number;
-        this.maxSeats = maxSeats;
-    }
-
     public static BlockRowEntity from(BlockRow blockRow) {
         return new BlockRowEntity(
-                blockRow.getId(),
-                blockRow.getBlockId(),
-                blockRow.getNumber(),
-                blockRow.getMaxSeats());
+                blockRow.getBlockId(), blockRow.getNumber(), blockRow.getMaxSeats());
     }
 
     public BlockRow toDomain() {
-        return new BlockRow(id, blockId, number, maxSeats);
+        return new BlockRow(this.getId(), blockId, number, maxSeats);
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/block/entity/BlockTopKeywordEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/block/entity/BlockTopKeywordEntity.java
@@ -2,23 +2,19 @@ package org.depromeet.spot.jpa.block.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.block.BlockTopKeyword;
+import org.depromeet.spot.jpa.common.entity.BaseEntity;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "block_top_keywords")
 @NoArgsConstructor
-public class BlockTopKeywordEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
+@AllArgsConstructor
+public class BlockTopKeywordEntity extends BaseEntity {
 
     @Column(name = "block_id", nullable = false)
     private Long blockId;
@@ -29,22 +25,14 @@ public class BlockTopKeywordEntity {
     @Column(name = "count", nullable = false)
     private Long count;
 
-    public BlockTopKeywordEntity(Long id, Long blockId, Long keywordId, Long count) {
-        this.id = id;
-        this.blockId = blockId;
-        this.keywordId = keywordId;
-        this.count = count;
-    }
-
     public static BlockTopKeywordEntity from(BlockTopKeyword blockTopKeyword) {
         return new BlockTopKeywordEntity(
-                blockTopKeyword.getId(),
                 blockTopKeyword.getBlockId(),
                 blockTopKeyword.getKeywordId(),
                 blockTopKeyword.getCount());
     }
 
     public BlockTopKeyword toDomain() {
-        return new BlockTopKeyword(id, blockId, keywordId, count);
+        return new BlockTopKeyword(this.getId(), blockId, keywordId, count);
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/common/entity/BaseEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/common/entity/BaseEntity.java
@@ -30,6 +30,7 @@ import lombok.experimental.SuperBuilder;
 public abstract class BaseEntity {
 
     @Id
+    @Column(name = "id", nullable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/common/entity/BaseEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/common/entity/BaseEntity.java
@@ -1,0 +1,63 @@
+package org.depromeet.spot.jpa.common.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+
+import org.hibernate.annotations.Where;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@MappedSuperclass
+@AllArgsConstructor
+@Where(clause = "deleted_at is null")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(updatable = false, name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return null != this.deletedAt;
+    }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/entity/MemberEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/entity/MemberEntity.java
@@ -1,26 +1,20 @@
 package org.depromeet.spot.jpa.member.entity;
 
-import java.time.LocalDateTime;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.member.Member;
+import org.depromeet.spot.jpa.common.entity.BaseEntity;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "members")
 @NoArgsConstructor
-public class MemberEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+@AllArgsConstructor
+public class MemberEntity extends BaseEntity {
 
     @Column(name = "email", nullable = false, unique = true, length = 50)
     private String email;
@@ -52,44 +46,8 @@ public class MemberEntity {
     @Column(name = "role", nullable = false)
     private Integer role;
 
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
-
-    public MemberEntity(
-            Long userId,
-            String email,
-            String name,
-            String nickname,
-            String phoneNumber,
-            Integer level,
-            String profileImage,
-            String snsProvider,
-            String idToken,
-            String myTeam,
-            Integer role,
-            LocalDateTime createdAt,
-            LocalDateTime deletedAt) {
-        this.userId = userId;
-        this.email = email;
-        this.name = name;
-        this.nickname = nickname;
-        this.phoneNumber = phoneNumber;
-        this.level = level;
-        this.profileImage = profileImage;
-        this.snsProvider = snsProvider;
-        this.idToken = idToken;
-        this.myTeam = myTeam;
-        this.role = role;
-        this.createdAt = createdAt;
-        this.deletedAt = deletedAt;
-    }
-
     public static MemberEntity from(Member member) {
         return new MemberEntity(
-                member.getUserId(),
                 member.getEmail(),
                 member.getName(),
                 member.getNickname(),
@@ -99,14 +57,12 @@ public class MemberEntity {
                 member.getSnsProvider(),
                 member.getIdToken(),
                 member.getMyTeam(),
-                member.getRole(),
-                member.getCreatedAt(),
-                member.getDeletedAt());
+                member.getRole());
     }
 
     public Member toDomain() {
         return new Member(
-                userId,
+                this.getId(),
                 email,
                 name,
                 nickname,
@@ -117,7 +73,7 @@ public class MemberEntity {
                 idToken,
                 myTeam,
                 role,
-                createdAt,
-                deletedAt);
+                this.getCreatedAt(),
+                this.getDeletedAt());
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/KeywordEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/KeywordEntity.java
@@ -2,37 +2,28 @@ package org.depromeet.spot.jpa.review.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.review.Keyword;
+import org.depromeet.spot.jpa.common.entity.BaseEntity;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "keywords")
 @NoArgsConstructor
-public class KeywordEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
+@AllArgsConstructor
+public class KeywordEntity extends BaseEntity {
 
     @Column(name = "content", nullable = false, length = 50)
     private String content;
 
-    public KeywordEntity(Long id, String content) {
-        this.id = id;
-        this.content = content;
-    }
-
     public static KeywordEntity from(Keyword keyword) {
-        return new KeywordEntity(keyword.getId(), keyword.getContent());
+        return new KeywordEntity(keyword.getContent());
     }
 
     public Keyword toDomain() {
-        return new Keyword(id, content);
+        return new Keyword(this.getId(), content);
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/ReviewEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/ReviewEntity.java
@@ -1,27 +1,22 @@
 package org.depromeet.spot.jpa.review.entity;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.jpa.common.entity.BaseEntity;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "reviews")
 @NoArgsConstructor
-public class ReviewEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
+@AllArgsConstructor
+public class ReviewEntity extends BaseEntity {
 
     @Column(name = "user_id", nullable = false)
     private Long userId;
@@ -38,73 +33,39 @@ public class ReviewEntity {
     @Column(name = "seat_number", nullable = false)
     private Long seatNumber;
 
-    @Column(name = "date", nullable = false)
-    private LocalDate date;
+    @Column(name = "dateTime", nullable = false)
+    private LocalDateTime dateTime;
 
     @Column(name = "content", length = 300)
     private String content;
 
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
-
     @Column(name = "status", nullable = false, length = 15)
     private String status;
 
-    public ReviewEntity(
-            Long id,
-            Long userId,
-            Long blockId,
-            Long seatId,
-            Long rowId,
-            Long seatNumber,
-            LocalDate date,
-            String content,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            String status) {
-        this.id = id;
-        this.userId = userId;
-        this.blockId = blockId;
-        this.seatId = seatId;
-        this.rowId = rowId;
-        this.seatNumber = seatNumber;
-        this.date = date;
-        this.content = content;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.status = status;
-    }
-
     public static ReviewEntity from(Review review) {
         return new ReviewEntity(
-                review.getId(),
                 review.getUserId(),
                 review.getBlockId(),
                 review.getSeatId(),
                 review.getRowId(),
                 review.getSeatNumber(),
-                review.getDate(),
+                review.getDateTime(),
                 review.getContent(),
-                review.getCreatedAt(),
-                review.getUpdatedAt(),
                 review.getStatus());
     }
 
     public Review toDomain() {
         return new Review(
-                id,
+                this.getId(),
                 userId,
                 blockId,
                 seatId,
                 rowId,
                 seatNumber,
-                date,
+                dateTime,
                 content,
-                createdAt,
-                updatedAt,
+                this.getCreatedAt(),
+                this.getUpdatedAt(),
                 status);
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/ReviewImageEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/ReviewImageEntity.java
@@ -1,26 +1,20 @@
 package org.depromeet.spot.jpa.review.entity;
 
-import java.time.LocalDateTime;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.review.ReviewImage;
+import org.depromeet.spot.jpa.common.entity.BaseEntity;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "review_images")
 @NoArgsConstructor
-public class ReviewImageEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
+@AllArgsConstructor
+public class ReviewImageEntity extends BaseEntity {
 
     @Column(name = "review_id", nullable = false)
     private Long reviewId;
@@ -28,31 +22,15 @@ public class ReviewImageEntity {
     @Column(name = "url", nullable = false, length = 255)
     private String url;
 
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
     @Column(name = "status", nullable = false, length = 15)
     private String status;
 
-    public ReviewImageEntity(
-            Long id, Long reviewId, String url, LocalDateTime createdAt, String status) {
-        this.id = id;
-        this.reviewId = reviewId;
-        this.url = url;
-        this.createdAt = createdAt;
-        this.status = status;
-    }
-
     public static ReviewImageEntity from(ReviewImage reviewImage) {
         return new ReviewImageEntity(
-                reviewImage.getId(),
-                reviewImage.getReviewId(),
-                reviewImage.getUrl(),
-                reviewImage.getCreatedAt(),
-                reviewImage.getStatus());
+                reviewImage.getReviewId(), reviewImage.getUrl(), reviewImage.getStatus());
     }
 
     public ReviewImage toDomain() {
-        return new ReviewImage(id, reviewId, url, createdAt, status);
+        return new ReviewImage(this.getId(), reviewId, url, this.getCreatedAt(), status);
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/ReviewKeywordEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/ReviewKeywordEntity.java
@@ -2,24 +2,19 @@ package org.depromeet.spot.jpa.review.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.review.ReviewKeyword;
+import org.depromeet.spot.jpa.common.entity.BaseEntity;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "review_keywords")
 @NoArgsConstructor
-public class ReviewKeywordEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
-
+@AllArgsConstructor
+public class ReviewKeywordEntity extends BaseEntity {
     @Column(name = "review_id", nullable = false)
     private Long reviewId;
 
@@ -29,22 +24,14 @@ public class ReviewKeywordEntity {
     @Column(name = "is_positive", nullable = false)
     private Boolean isPositive;
 
-    public ReviewKeywordEntity(Long id, Long reviewId, Long keywordId, Boolean isPositive) {
-        this.id = id;
-        this.reviewId = reviewId;
-        this.keywordId = keywordId;
-        this.isPositive = isPositive;
-    }
-
     public static ReviewKeywordEntity from(ReviewKeyword reviewKeyword) {
         return new ReviewKeywordEntity(
-                reviewKeyword.getId(),
                 reviewKeyword.getReviewId(),
                 reviewKeyword.getKeywordId(),
                 reviewKeyword.getIsPositive());
     }
 
     public ReviewKeyword toDomain() {
-        return new ReviewKeyword(id, reviewId, keywordId, isPositive);
+        return new ReviewKeyword(this.getId(), reviewId, keywordId, isPositive);
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/seat/entity/SeatEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/seat/entity/SeatEntity.java
@@ -2,23 +2,19 @@ package org.depromeet.spot.jpa.seat.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.seat.Seat;
+import org.depromeet.spot.jpa.common.entity.BaseEntity;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "seats")
 @NoArgsConstructor
-public class SeatEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
+@AllArgsConstructor
+public class SeatEntity extends BaseEntity {
 
     @Column(name = "stadium_id", nullable = false)
     private Long stadiumId;
@@ -35,19 +31,8 @@ public class SeatEntity {
     @Column(name = "seat_number", nullable = false)
     private Integer seatNumber;
 
-    public SeatEntity(
-            Long id, Long stadiumId, Long sectionId, Long blockId, Long rowId, Integer seatNumber) {
-        this.id = id;
-        this.stadiumId = stadiumId;
-        this.sectionId = sectionId;
-        this.blockId = blockId;
-        this.rowId = rowId;
-        this.seatNumber = seatNumber;
-    }
-
     public static SeatEntity from(Seat seat) {
         return new SeatEntity(
-                seat.getId(),
                 seat.getStadiumId(),
                 seat.getSectionId(),
                 seat.getBlockId(),
@@ -56,6 +41,6 @@ public class SeatEntity {
     }
 
     public Seat toDomain() {
-        return new Seat(id, stadiumId, sectionId, blockId, rowId, seatNumber);
+        return new Seat(this.getId(), stadiumId, sectionId, blockId, rowId, seatNumber);
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/section/entity/SectionEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/section/entity/SectionEntity.java
@@ -2,24 +2,20 @@ package org.depromeet.spot.jpa.section.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.common.RgbCode;
 import org.depromeet.spot.domain.section.Section;
+import org.depromeet.spot.jpa.common.entity.BaseEntity;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "sections")
 @NoArgsConstructor
-public class SectionEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
+@AllArgsConstructor
+public class SectionEntity extends BaseEntity {
 
     @Column(name = "stadium_id", nullable = false)
     private Long stadiumId;
@@ -39,27 +35,9 @@ public class SectionEntity {
     @Column(name = "blue")
     private Integer blue;
 
-    public SectionEntity(
-            Long id,
-            Long stadiumId,
-            String name,
-            String alias,
-            Integer red,
-            Integer green,
-            Integer blue) {
-        this.id = id;
-        this.stadiumId = stadiumId;
-        this.name = name;
-        this.alias = alias;
-        this.red = red;
-        this.green = green;
-        this.blue = blue;
-    }
-
     public static SectionEntity from(Section section) {
         RgbCode labelRgbCode = section.getLabelRgbCode();
         return new SectionEntity(
-                section.getId(),
                 section.getStadiumId(),
                 section.getName(),
                 section.getAlias(),
@@ -70,6 +48,6 @@ public class SectionEntity {
 
     public Section toDomain() {
         RgbCode rgbCode = RgbCode.builder().red(red).green(green).blue(blue).build();
-        return new Section(id, stadiumId, name, alias, rgbCode);
+        return new Section(this.getId(), stadiumId, name, alias, rgbCode);
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/stadium/entity/StadiumEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/stadium/entity/StadiumEntity.java
@@ -2,23 +2,19 @@ package org.depromeet.spot.jpa.stadium.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.stadium.Stadium;
+import org.depromeet.spot.jpa.common.entity.BaseEntity;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "stadiums")
 @NoArgsConstructor
-public class StadiumEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
+@AllArgsConstructor
+public class StadiumEntity extends BaseEntity {
 
     @Column(name = "name", nullable = false, length = 50)
     private String name;
@@ -35,24 +31,8 @@ public class StadiumEntity {
     @Column(name = "is_active", nullable = false)
     private boolean isActive;
 
-    public StadiumEntity(
-            Long id,
-            String name,
-            String mainImage,
-            String seatingChartImage,
-            String labeledSeatingChartImage,
-            boolean isActive) {
-        this.id = id;
-        this.name = name;
-        this.mainImage = mainImage;
-        this.seatingChartImage = seatingChartImage;
-        this.labeledSeatingChartImage = labeledSeatingChartImage;
-        this.isActive = isActive;
-    }
-
     public static StadiumEntity from(Stadium stadium) {
         return new StadiumEntity(
-                stadium.getId(),
                 stadium.getName(),
                 stadium.getMainImage(),
                 stadium.getSeatingChartImage(),
@@ -62,7 +42,7 @@ public class StadiumEntity {
 
     public Stadium toDomain() {
         return Stadium.builder()
-                .id(id)
+                .id(this.getId())
                 .name(name)
                 .mainImage(mainImage)
                 .seatingChartImage(seatingChartImage)

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/team/entity/BaseballTeamEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/team/entity/BaseballTeamEntity.java
@@ -2,24 +2,20 @@ package org.depromeet.spot.jpa.team.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.common.RgbCode;
 import org.depromeet.spot.domain.team.BaseballTeam;
+import org.depromeet.spot.jpa.common.entity.BaseEntity;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "baseball_teams")
 @NoArgsConstructor
-public class BaseballTeamEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
+@AllArgsConstructor
+public class BaseballTeamEntity extends BaseEntity {
 
     @Column(name = "name", nullable = false, length = 20)
     private String name;
@@ -39,27 +35,9 @@ public class BaseballTeamEntity {
     @Column(name = "blue")
     private Integer blue;
 
-    public BaseballTeamEntity(
-            Long id,
-            String name,
-            String alias,
-            String logo,
-            Integer red,
-            Integer green,
-            Integer blue) {
-        this.id = id;
-        this.name = name;
-        this.alias = alias;
-        this.logo = logo;
-        this.red = red;
-        this.green = green;
-        this.blue = blue;
-    }
-
     public static BaseballTeamEntity from(BaseballTeam baseballTeam) {
         RgbCode labelRgbCode = baseballTeam.getLabelRgbCode();
         return new BaseballTeamEntity(
-                baseballTeam.getId(),
                 baseballTeam.getName(),
                 baseballTeam.getAlias(),
                 baseballTeam.getLogo(),
@@ -70,6 +48,6 @@ public class BaseballTeamEntity {
 
     public BaseballTeam toDomain() {
         RgbCode labelRgbCode = RgbCode.builder().red(red).green(green).blue(blue).build();
-        return new BaseballTeam(id, name, alias, logo, labelRgbCode);
+        return new BaseballTeam(this.getId(), name, alias, logo, labelRgbCode);
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/team/entity/StadiumHomeTeamEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/team/entity/StadiumHomeTeamEntity.java
@@ -2,23 +2,19 @@ package org.depromeet.spot.jpa.team.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.team.StadiumHomeTeam;
+import org.depromeet.spot.jpa.common.entity.BaseEntity;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "stadium_home_teams")
 @NoArgsConstructor
-public class StadiumHomeTeamEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
+@AllArgsConstructor
+public class StadiumHomeTeamEntity extends BaseEntity {
 
     @Column(name = "stadium_id", nullable = false)
     private Long stadiumId;
@@ -26,20 +22,12 @@ public class StadiumHomeTeamEntity {
     @Column(name = "team_id", nullable = false)
     private Long teamId;
 
-    public StadiumHomeTeamEntity(Long id, Long stadiumId, Long teamId) {
-        this.id = id;
-        this.stadiumId = stadiumId;
-        this.teamId = teamId;
-    }
-
     public static StadiumHomeTeamEntity from(StadiumHomeTeam stadiumHomeTeam) {
         return new StadiumHomeTeamEntity(
-                stadiumHomeTeam.getId(),
-                stadiumHomeTeam.getStadiumId(),
-                stadiumHomeTeam.getTeamId());
+                stadiumHomeTeam.getStadiumId(), stadiumHomeTeam.getTeamId());
     }
 
     public StadiumHomeTeam toDomain() {
-        return new StadiumHomeTeam(id, stadiumId, teamId);
+        return new StadiumHomeTeam(this.getId(), stadiumId, teamId);
     }
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- 변경된 DB 컨벤션에 맞춰 BaseEntity를 생성하고, 엔티티 클래스에 적용했어요.

<br>

## 🔨 작업 사항 (필수)

- entity들에 BaseEntity 적용 및 충돌 코드 수정

<br>

## 🌱 연관 내용 (선택)

- 각자 작업 진행 중일 것 같아서 entity만 수정하고 도메인은 그대로 뒀어용
- 도메인 클래스는 담당자가 작업하면서 필요에 따라 변경해주시면 됩니다~!
  - 이제 DB 테이블에는 id, created_at, updated_at, deleted_at 전부 저장되니 각 도메인에선 당장 필요한 필드만 추가하면 될 것 같아용
  - 지금 당장은 도메인에 추가 안해도, 나중에 필요할때 추가하면 디비에서 꺼내올 수 있으니 문제 없음! ✨
- **created_at, updated_at은 @PrePersist, @PreUpdate를 통해 동작해요. 즉, 어플리케이션을 통해서가 아니라 DB에 sql을 직접 날리는 경우엔 동작하지 않아요 (data.sql로 데이터 삽입하는 경우 등)** 
  - 지금은 ddl-auto를 이용해 스키마를 생성하지만, 실제 개발 / 운영 환경에선 직접 ddl 스크립트를 작성해야해요.
  - 그때 테이블 각 필드 created_at, updated_at에 디폴트 값을 배정해주어야 합니덩

