### PR TITLE
[BSVR-97] 특정 경기장 구역 내 블럭 리스트 조회

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/block/BlockReadController.java
+++ b/application/src/main/java/org/depromeet/spot/application/block/BlockReadController.java
@@ -1,0 +1,44 @@
+package org.depromeet.spot.application.block;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import org.depromeet.spot.application.block.dto.response.BlockCodeInfoResponse;
+import org.depromeet.spot.usecase.port.in.block.BlockReadUsecase;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@Tag(name = "블록")
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class BlockReadController {
+
+    private final BlockReadUsecase blockReadUsecase;
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/stadiums/{stadiumId}/sections/{sectionId}/blocks")
+    @Operation(summary = "특정 야구 경기장 특정 구역 내의 블록 리스트를 조회한다.")
+    public List<BlockCodeInfoResponse> findCodeInfosByStadium(
+            @PathVariable("stadiumId")
+                    @NotNull
+                    @Positive
+                    @Parameter(name = "stadiumId", description = "야구 경기장 PK", required = true)
+                    final Long stadiumId,
+            @PathVariable("sectionId")
+                    @NotNull
+                    @Positive
+                    @Parameter(name = "sectionId", description = "구역 PK", required = true)
+                    final Long sectionId) {}
+}

--- a/application/src/main/java/org/depromeet/spot/application/block/BlockReadController.java
+++ b/application/src/main/java/org/depromeet/spot/application/block/BlockReadController.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Positive;
 
 import org.depromeet.spot.application.block.dto.response.BlockCodeInfoResponse;
 import org.depromeet.spot.usecase.port.in.block.BlockReadUsecase;
+import org.depromeet.spot.usecase.port.in.block.BlockReadUsecase.BlockCodeInfo;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -40,5 +41,8 @@ public class BlockReadController {
                     @NotNull
                     @Positive
                     @Parameter(name = "sectionId", description = "구역 PK", required = true)
-                    final Long sectionId) {}
+                    final Long sectionId) {
+        List<BlockCodeInfo> infos = blockReadUsecase.findCodeInfosByStadium(stadiumId, sectionId);
+        return infos.stream().map(BlockCodeInfoResponse::from).toList();
+    }
 }

--- a/application/src/main/java/org/depromeet/spot/application/block/dto/response/BlockCodeInfoResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/block/dto/response/BlockCodeInfoResponse.java
@@ -1,0 +1,10 @@
+package org.depromeet.spot.application.block.dto.response;
+
+import org.depromeet.spot.usecase.port.in.block.BlockReadUsecase.BlockCodeInfo;
+
+public record BlockCodeInfoResponse(Long id, String code) {
+
+    public static BlockCodeInfoResponse from(BlockCodeInfo blockCodeInfo) {
+        return new BlockCodeInfoResponse(blockCodeInfo.getId(), blockCodeInfo.getCode());
+    }
+}

--- a/common/src/main/java/org/depromeet/spot/common/exception/section/SectionErrorCode.java
+++ b/common/src/main/java/org/depromeet/spot/common/exception/section/SectionErrorCode.java
@@ -1,0 +1,28 @@
+package org.depromeet.spot.common.exception.section;
+
+import org.depromeet.spot.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public enum SectionErrorCode implements ErrorCode {
+    SECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "SE001", "요청 구역이 존재하지 않습니다."),
+    SECTION_NOT_BELONG_TO_STADIUM(HttpStatus.BAD_REQUEST, "SE002", "요청 경기장의 구역이 아닙니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private String message;
+
+    SectionErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    public SectionErrorCode appended(Object o) {
+        message = message + " {" + o.toString() + "}";
+        return this;
+    }
+}

--- a/common/src/main/java/org/depromeet/spot/common/exception/section/SectionException.java
+++ b/common/src/main/java/org/depromeet/spot/common/exception/section/SectionException.java
@@ -1,0 +1,22 @@
+package org.depromeet.spot.common.exception.section;
+
+import org.depromeet.spot.common.exception.BusinessException;
+
+public abstract class SectionException extends BusinessException {
+
+    protected SectionException(SectionErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public static class SectionNotFoundException extends SectionException {
+        public SectionNotFoundException() {
+            super(SectionErrorCode.SECTION_NOT_FOUND);
+        }
+    }
+
+    public static class SectionNotBelongStadiumException extends SectionException {
+        public SectionNotBelongStadiumException() {
+            super(SectionErrorCode.SECTION_NOT_BELONG_TO_STADIUM);
+        }
+    }
+}

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/block/repository/BlockJpaRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/block/repository/BlockJpaRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BlockJpaRepository extends JpaRepository<BlockEntity, Long> {
 
-    List<BlockEntity> findAllByStadiumId(Long stadiumId);
+    List<BlockEntity> findAllBySectionId(Long sectionId);
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/block/repository/BlockJpaRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/block/repository/BlockJpaRepository.java
@@ -1,0 +1,11 @@
+package org.depromeet.spot.jpa.block.repository;
+
+import java.util.List;
+
+import org.depromeet.spot.jpa.block.entity.BlockEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlockJpaRepository extends JpaRepository<BlockEntity, Long> {
+
+    List<BlockEntity> findAllByStadiumId(Long stadiumId);
+}

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/block/repository/BlockRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/block/repository/BlockRepositoryImpl.java
@@ -1,0 +1,23 @@
+package org.depromeet.spot.jpa.block.repository;
+
+import java.util.List;
+
+import org.depromeet.spot.domain.block.Block;
+import org.depromeet.spot.jpa.block.entity.BlockEntity;
+import org.depromeet.spot.usecase.port.out.block.BlockRepository;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BlockRepositoryImpl implements BlockRepository {
+
+    private final BlockJpaRepository blockJpaRepository;
+
+    @Override
+    public List<Block> findAllByStadium(final Long stadiumId) {
+        List<BlockEntity> entities = blockJpaRepository.findAllByStadiumId(stadiumId);
+        return entities.stream().map(BlockEntity::toDomain).toList();
+    }
+}

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/block/repository/BlockRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/block/repository/BlockRepositoryImpl.java
@@ -16,8 +16,8 @@ public class BlockRepositoryImpl implements BlockRepository {
     private final BlockJpaRepository blockJpaRepository;
 
     @Override
-    public List<Block> findAllByStadium(final Long stadiumId) {
-        List<BlockEntity> entities = blockJpaRepository.findAllByStadiumId(stadiumId);
+    public List<Block> findAllBySection(final Long sectionId) {
+        List<BlockEntity> entities = blockJpaRepository.findAllBySectionId(sectionId);
         return entities.stream().map(BlockEntity::toDomain).toList();
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/section/repository/SectionJpaRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/section/repository/SectionJpaRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface SectionJpaRepository extends JpaRepository<SectionEntity, Long> {
 
     List<SectionEntity> findAllByStadiumId(Long stadiumId);
+
+    boolean existsByStadiumIdAndId(Long stadiumId, Long id);
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/section/repository/SectionRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/section/repository/SectionRepositoryImpl.java
@@ -26,4 +26,9 @@ public class SectionRepositoryImpl implements SectionRepository {
         // TODO: test를 위해 추가 -> 구역 생성 티켓 작업할 때 구현 예정
         return null;
     }
+
+    @Override
+    public boolean existsInStadium(Long stadiumId, Long sectionId) {
+        return sectionJpaRepository.existsByStadiumIdAndId(stadiumId, sectionId);
+    }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/stadium/repository/StadiumRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/stadium/repository/StadiumRepositoryImpl.java
@@ -35,4 +35,9 @@ public class StadiumRepositoryImpl implements StadiumRepository {
         // TODO: test를 위해 추가 -> 구장 저장 API 티켓때 구현 예정
         return null;
     }
+
+    @Override
+    public boolean existsById(final Long id) {
+        return stadiumJpaRepository.existsById(id);
+    }
 }

--- a/infrastructure/jpa/src/main/resources/data.sql
+++ b/infrastructure/jpa/src/main/resources/data.sql
@@ -24,7 +24,7 @@ VALUES (1, 1, '오렌지석', '응원석', 255, 255, 255),
        (3, 1, '레드석', null, 100, 0, 0);
 
 -- Section Blocks
-INSERT INTO blocks (id, stadium_id, section_id, code, maxRows)
+INSERT INTO blocks (id, stadium_id, section_id, code, max_rows)
 VALUES (1, 1, 1, "207", 18),
        (2, 1, 1, "208", 39),
        (3, 1, 2, "108", 10);

--- a/infrastructure/jpa/src/main/resources/data.sql
+++ b/infrastructure/jpa/src/main/resources/data.sql
@@ -22,3 +22,9 @@ INSERT INTO sections (id, stadium_id, name, alias, red, green, blue)
 VALUES (1, 1, '오렌지석', '응원석', 255, 255, 255),
        (2, 1, '네이비석', '프리미엄석', 100, 100, 100),
        (3, 1, '레드석', null, 100, 0, 0);
+
+-- Section Blocks
+INSERT INTO blocks (id, stadium_id, section_id, code, maxRows)
+VALUES (1, 1, 1, "207", 18),
+       (2, 1, 1, "208", 39),
+       (3, 1, 2, "108", 10);

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/block/BlockReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/block/BlockReadUsecase.java
@@ -1,0 +1,18 @@
+package org.depromeet.spot.usecase.port.in.block;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public interface BlockReadUsecase {
+
+    List<BlockCodeInfo> findCodeInfosByStadium(Long stadiumId);
+
+    @Getter
+    @AllArgsConstructor
+    class BlockCodeInfo {
+        private final Long id;
+        private final String code;
+    }
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/block/BlockReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/block/BlockReadUsecase.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 public interface BlockReadUsecase {
 
-    List<BlockCodeInfo> findCodeInfosByStadium(Long stadiumId);
+    List<BlockCodeInfo> findCodeInfosByStadium(Long stadiumId, Long sectionId);
 
     @Getter
     @AllArgsConstructor

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/section/SectionReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/section/SectionReadUsecase.java
@@ -13,6 +13,8 @@ public interface SectionReadUsecase {
 
     StadiumSections findAllByStadium(Long stadiumId);
 
+    boolean existsInStadium(Long stadiumId, Long sectionId);
+
     @Getter
     @AllArgsConstructor
     class StadiumSections {

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/StadiumReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/StadiumReadUsecase.java
@@ -19,6 +19,8 @@ public interface StadiumReadUsecase {
 
     Stadium findById(Long id);
 
+    boolean existsById(Long id);
+
     @Getter
     @AllArgsConstructor
     class StadiumHomeTeamInfo {

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/block/BlockRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/block/BlockRepository.java
@@ -1,0 +1,10 @@
+package org.depromeet.spot.usecase.port.out.block;
+
+import java.util.List;
+
+import org.depromeet.spot.domain.block.Block;
+
+public interface BlockRepository {
+
+    List<Block> findAllByStadium(Long stadiumId);
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/block/BlockRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/block/BlockRepository.java
@@ -6,5 +6,5 @@ import org.depromeet.spot.domain.block.Block;
 
 public interface BlockRepository {
 
-    List<Block> findAllByStadium(Long stadiumId);
+    List<Block> findAllBySection(Long sectionId);
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/section/SectionRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/section/SectionRepository.java
@@ -9,4 +9,6 @@ public interface SectionRepository {
     List<Section> findAllByStadium(Long stadiumId);
 
     Section save(Section section);
+
+    boolean existsInStadium(Long stadiumId, Long sectionId);
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/stadium/StadiumRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/stadium/StadiumRepository.java
@@ -10,4 +10,6 @@ public interface StadiumRepository {
     List<Stadium> findAll();
 
     Stadium save(Stadium stadium);
+
+    boolean existsById(Long id);
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/block/BlockReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/block/BlockReadService.java
@@ -1,0 +1,29 @@
+package org.depromeet.spot.usecase.service.block;
+
+import java.util.List;
+
+import org.depromeet.spot.common.exception.stadium.StadiumException.StadiumNotFoundException;
+import org.depromeet.spot.domain.block.Block;
+import org.depromeet.spot.usecase.port.in.block.BlockReadUsecase;
+import org.depromeet.spot.usecase.port.in.stadium.StadiumReadUsecase;
+import org.depromeet.spot.usecase.port.out.block.BlockRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BlockReadService implements BlockReadUsecase {
+
+    private final BlockRepository blockRepository;
+    private final StadiumReadUsecase stadiumReadUsecase;
+
+    @Override
+    public List<BlockCodeInfo> findCodeInfosByStadium(final Long stadiumId) {
+        if (!stadiumReadUsecase.existsById(stadiumId)) {
+            throw new StadiumNotFoundException();
+        }
+        List<Block> blocks = blockRepository.findAllByStadium(stadiumId);
+        return blocks.stream().map(b -> new BlockCodeInfo(b.getId(), b.getCode())).toList();
+    }
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/block/BlockReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/block/BlockReadService.java
@@ -2,9 +2,11 @@ package org.depromeet.spot.usecase.service.block;
 
 import java.util.List;
 
+import org.depromeet.spot.common.exception.section.SectionException.SectionNotBelongStadiumException;
 import org.depromeet.spot.common.exception.stadium.StadiumException.StadiumNotFoundException;
 import org.depromeet.spot.domain.block.Block;
 import org.depromeet.spot.usecase.port.in.block.BlockReadUsecase;
+import org.depromeet.spot.usecase.port.in.section.SectionReadUsecase;
 import org.depromeet.spot.usecase.port.in.stadium.StadiumReadUsecase;
 import org.depromeet.spot.usecase.port.out.block.BlockRepository;
 import org.springframework.stereotype.Service;
@@ -17,13 +19,17 @@ public class BlockReadService implements BlockReadUsecase {
 
     private final BlockRepository blockRepository;
     private final StadiumReadUsecase stadiumReadUsecase;
+    private final SectionReadUsecase sectionReadUsecase;
 
     @Override
-    public List<BlockCodeInfo> findCodeInfosByStadium(final Long stadiumId) {
+    public List<BlockCodeInfo> findCodeInfosByStadium(final Long stadiumId, final Long sectionId) {
         if (!stadiumReadUsecase.existsById(stadiumId)) {
             throw new StadiumNotFoundException();
         }
-        List<Block> blocks = blockRepository.findAllByStadium(stadiumId);
+        if (!sectionReadUsecase.existsInStadium(stadiumId, sectionId)) {
+            throw new SectionNotBelongStadiumException();
+        }
+        List<Block> blocks = blockRepository.findAllBySection(sectionId);
         return blocks.stream().map(b -> new BlockCodeInfo(b.getId(), b.getCode())).toList();
     }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/section/SectionReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/section/SectionReadService.java
@@ -30,6 +30,6 @@ public class SectionReadService implements SectionReadUsecase {
 
     @Override
     public boolean existsInStadium(final Long stadiumId, final Long sectionId) {
-        return false;
+        return sectionRepository.existsInStadium(stadiumId, sectionId);
     }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/section/SectionReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/section/SectionReadService.java
@@ -27,4 +27,9 @@ public class SectionReadService implements SectionReadUsecase {
         List<SectionInfo> sectionInfos = sections.stream().map(SectionInfo::from).toList();
         return new StadiumSections(stadium.getSeatingChartImage(), sectionInfos);
     }
+
+    @Override
+    public boolean existsInStadium(final Long stadiumId, final Long sectionId) {
+        return false;
+    }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/StadiumReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/StadiumReadService.java
@@ -74,4 +74,9 @@ public class StadiumReadService implements StadiumReadUsecase {
     public Stadium findById(final Long id) {
         return stadiumRepository.findById(id);
     }
+
+    @Override
+    public boolean existsById(final Long id) {
+        return stadiumRepository.existsById(id);
+    }
 }

--- a/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeSectionRepository.java
+++ b/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeSectionRepository.java
@@ -38,4 +38,11 @@ public class FakeSectionRepository implements SectionRepository {
             return section;
         }
     }
+
+    @Override
+    public boolean existsInStadium(Long stadiumId, Long sectionId) {
+        return data.stream()
+                .filter(section -> section.getStadiumId().equals(sectionId))
+                .anyMatch(section -> section.getId().equals(sectionId));
+    }
 }

--- a/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeStadiumRepository.java
+++ b/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeStadiumRepository.java
@@ -50,4 +50,9 @@ public class FakeStadiumRepository implements StadiumRepository {
             return stadium;
         }
     }
+
+    @Override
+    public boolean existsById(final Long id) {
+        return data.stream().anyMatch(stadium -> stadium.getId().equals(id));
+    }
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- 경기장 구역 내 블럭 리스트 조회 API

<br>

## 🔨 작업 사항 (필수)

- 특정 구역 내의 블럭 리스트 조회
- 경기장 내 구역 존재 여부 체크 repository

<br>

## 💻 실행 화면 (필수)

- 성공
<img width="1083" alt="스크린샷 2024-07-14 오전 5 32 19" src="https://github.com/user-attachments/assets/4d472b7d-ba71-4686-a63c-ddda98437757">

- 실패 : 존재하지 않는 경기장
<img width="1065" alt="스크린샷 2024-07-14 오전 5 26 50" src="https://github.com/user-attachments/assets/39b9c6e0-f379-4e8d-a434-bbe08cdfd642">

- 실패 : 경기장 내 구역 아님
<img width="1075" alt="스크린샷 2024-07-14 오전 5 27 05" src="https://github.com/user-attachments/assets/a5c0cacf-e994-4775-b906-3380551906fe">
