### PR TITLE
[BSVR-118] 블록별 리뷰 조회 API 구현

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/review/ReviewReadController.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/ReviewReadController.java
@@ -1,0 +1,58 @@
+package org.depromeet.spot.application.review;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+
+import org.depromeet.spot.application.review.dto.response.ReviewListResponse;
+import org.depromeet.spot.domain.review.ReviewListResult;
+import org.depromeet.spot.usecase.port.in.review.ReviewReadUsecase;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@Tag(name = "리뷰")
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class ReviewReadController {
+
+    private final ReviewReadUsecase reviewReadUsecase;
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/stadiums/{stadiumId}/blocks/{blockId}/reviews")
+    @Operation(summary = "특정 야구장의 특정 블록에 대한 리뷰 목록을 조회한다.")
+    public ReviewListResponse findReviewsByBlockId(
+            @PathVariable("stadiumId")
+                    @NotNull
+                    @Positive
+                    @Parameter(description = "야구장 PK", required = true)
+                    Long stadiumId,
+            @PathVariable("blockId")
+                    @NotNull
+                    @Positive
+                    @Parameter(description = "블록 PK", required = true)
+                    Long blockId,
+            @RequestParam(required = false) @Parameter(description = "열 ID (필터링)") Long rowId,
+            @RequestParam(required = false) @Parameter(description = "좌석 번호 (필터링)") Long seatNumber,
+            @RequestParam(defaultValue = "0")
+                    @PositiveOrZero
+                    @Parameter(description = "시작 위치 (기본값: 0)")
+                    int offset,
+            @RequestParam(defaultValue = "10")
+                    @Positive
+                    @Max(50)
+                    @Parameter(description = "조회할 리뷰 수 (기본값: 10, 최대: 50)")
+                    int limit) {
+
+        ReviewListResult result =
+                reviewReadUsecase.findReviewsByBlockId(
+                        stadiumId, blockId, rowId, seatNumber, offset, limit);
+        return ReviewListResponse.from(result);
+    }
+}

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/request/ReviewBlockRequest.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/request/ReviewBlockRequest.java
@@ -1,0 +1,17 @@
+package org.depromeet.spot.application.review.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.PositiveOrZero;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+public record ReviewBlockRequest(
+        @Parameter(description = "열 ID (필터링)") Long rowId,
+        @Parameter(description = "좌석 번호 (필터링)") Long seatNumber,
+        @PositiveOrZero @Parameter(description = "시작 위치 (기본값: 0)") int offset,
+        @Max(50) @Parameter(description = "조회할 리뷰 수 (기본값: 10, 최대: 50)") int limit) {
+    public ReviewBlockRequest {
+        if (offset == 0) offset = 0;
+        if (limit == 0) limit = 10;
+    }
+}

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/ReviewListResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/ReviewListResponse.java
@@ -1,0 +1,43 @@
+package org.depromeet.spot.application.review.dto.response;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.depromeet.spot.domain.review.ReviewListResult;
+
+public record ReviewListResponse(
+        List<KeywordCountResponse> keywords,
+        List<ReviewResponse> reviews,
+        int totalCount,
+        int filteredCount,
+        int offset,
+        int limit,
+        boolean hasMore,
+        FilterInfo filter) {
+    public static ReviewListResponse from(ReviewListResult result) {
+        List<ReviewResponse> reviewResponses =
+                result.reviews().stream().map(ReviewResponse::from).collect(Collectors.toList());
+
+        List<KeywordCountResponse> keywordResponses =
+                result.topKeywords().stream()
+                        .map(kc -> new KeywordCountResponse(kc.content(), kc.count()))
+                        .collect(Collectors.toList());
+
+        boolean hasMore = (result.offset() + result.reviews().size()) < result.totalCount();
+        FilterInfo filter = new FilterInfo(null, null); // Assuming no filter info for now
+
+        return new ReviewListResponse(
+                keywordResponses,
+                reviewResponses,
+                result.totalCount(),
+                result.reviews().size(),
+                result.offset(),
+                result.limit(),
+                hasMore,
+                filter);
+    }
+
+    record KeywordCountResponse(String content, Long count) {}
+
+    record FilterInfo(Long rowId, Integer seatNumber) {}
+}

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/ReviewResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/ReviewResponse.java
@@ -1,0 +1,60 @@
+package org.depromeet.spot.application.review.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.domain.review.ReviewImage;
+import org.depromeet.spot.domain.review.ReviewKeyword;
+
+public record ReviewResponse(
+        Long id,
+        Long userId,
+        Long blockId,
+        Long seatId,
+        Long rowId,
+        Long seatNumber,
+        LocalDateTime date,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        List<ImageResponse> images,
+        List<KeywordResponse> keywords) {
+    public static ReviewResponse from(Review review) {
+        return new ReviewResponse(
+                review.getId(),
+                review.getUserId(),
+                review.getBlockId(),
+                review.getSeatId(),
+                review.getRowId(),
+                review.getSeatNumber(),
+                review.getDateTime(),
+                review.getContent(),
+                review.getCreatedAt(),
+                review.getUpdatedAt(),
+                mapToImageResponses(review.getImages()),
+                mapToKeywordResponses(review.getKeywords()));
+    }
+
+    private static List<ImageResponse> mapToImageResponses(List<ReviewImage> images) {
+        return images.stream()
+                .map(image -> new ImageResponse(image.getId(), image.getUrl()))
+                .collect(Collectors.toList());
+    }
+
+    private static List<KeywordResponse> mapToKeywordResponses(List<ReviewKeyword> keywords) {
+        return keywords.stream()
+                .map(
+                        keyword ->
+                                new KeywordResponse(
+                                        keyword.getId(),
+                                        keyword.getKeywordId(),
+                                        keyword.getIsPositive()))
+                .collect(Collectors.toList());
+    }
+
+    record ImageResponse(Long id, String url) {}
+
+    record KeywordResponse(Long id, Long keywordId, Boolean isPositive) {}
+}

--- a/common/src/main/java/org/depromeet/spot/common/exception/review/ReviewErrorCode.java
+++ b/common/src/main/java/org/depromeet/spot/common/exception/review/ReviewErrorCode.java
@@ -1,0 +1,27 @@
+package org.depromeet.spot.common.exception.review;
+
+import org.depromeet.spot.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public enum ReviewErrorCode implements ErrorCode {
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "RV001", "요청한 리뷰를 찾을 수 없습니다."),
+    INVALID_REVIEW_DATA(HttpStatus.BAD_REQUEST, "RV002", "유효하지 않은 리뷰 데이터입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private String message;
+
+    ReviewErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    public ReviewErrorCode appended(Object o) {
+        message = message + " {" + o.toString() + "}";
+        return this;
+    }
+}

--- a/common/src/main/java/org/depromeet/spot/common/exception/review/ReviewException.java
+++ b/common/src/main/java/org/depromeet/spot/common/exception/review/ReviewException.java
@@ -1,0 +1,29 @@
+package org.depromeet.spot.common.exception.review;
+
+import org.depromeet.spot.common.exception.BusinessException;
+
+public abstract class ReviewException extends BusinessException {
+    protected ReviewException(ReviewErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public static class ReviewNotFoundException extends ReviewException {
+        public ReviewNotFoundException() {
+            super(ReviewErrorCode.REVIEW_NOT_FOUND);
+        }
+
+        public ReviewNotFoundException(String s) {
+            super(ReviewErrorCode.REVIEW_NOT_FOUND.appended(s));
+        }
+    }
+
+    public static class InvalidReviewDataException extends ReviewException {
+        public InvalidReviewDataException() {
+            super(ReviewErrorCode.INVALID_REVIEW_DATA);
+        }
+
+        public InvalidReviewDataException(String str) {
+            super(ReviewErrorCode.INVALID_REVIEW_DATA.appended(str));
+        }
+    }
+}

--- a/domain/src/main/java/org/depromeet/spot/domain/block/BlockTopKeyword.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/block/BlockTopKeyword.java
@@ -1,18 +1,13 @@
 package org.depromeet.spot.domain.block;
 
+import lombok.Builder;
 import lombok.Getter;
 
+@Builder
 @Getter
 public class BlockTopKeyword {
     private final Long id;
     private final Long blockId;
     private final Long keywordId;
     private final Long count;
-
-    public BlockTopKeyword(Long id, Long blockId, Long keywordId, Long count) {
-        this.id = id;
-        this.blockId = blockId;
-        this.keywordId = keywordId;
-        this.count = count;
-    }
 }

--- a/domain/src/main/java/org/depromeet/spot/domain/review/Keyword.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/review/Keyword.java
@@ -1,15 +1,12 @@
 package org.depromeet.spot.domain.review;
 
+import lombok.Builder;
 import lombok.Getter;
 
+@Builder
 @Getter
 public class Keyword {
 
     private final Long id;
     private final String content;
-
-    public Keyword(Long id, String content) {
-        this.id = id;
-        this.content = content;
-    }
 }

--- a/domain/src/main/java/org/depromeet/spot/domain/review/KeywordCount.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/review/KeywordCount.java
@@ -1,0 +1,3 @@
+package org.depromeet.spot.domain.review;
+
+public record KeywordCount(String content, Long count) {}

--- a/domain/src/main/java/org/depromeet/spot/domain/review/Review.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/review/Review.java
@@ -15,7 +15,7 @@ public class Review {
     private final Long seatId;
     private final Long rowId;
     private final Long seatNumber;
-    private final LocalDateTime date; // 시간은 미표기
+    private final LocalDateTime dateTime; // 시간은 미표기
     private final String content;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;

--- a/domain/src/main/java/org/depromeet/spot/domain/review/Review.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/review/Review.java
@@ -1,10 +1,11 @@
 package org.depromeet.spot.domain.review;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import lombok.Builder;
 import lombok.Getter;
 
+@Builder
 @Getter
 public class Review {
 
@@ -14,34 +15,9 @@ public class Review {
     private final Long seatId;
     private final Long rowId;
     private final Long seatNumber;
-    private final LocalDate date; // 시간은 미표기
+    private final LocalDateTime date; // 시간은 미표기
     private final String content;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
-    private final String status;
-
-    public Review(
-            Long id,
-            Long userId,
-            Long blockId,
-            Long seatId,
-            Long rowId,
-            Long seatNumber,
-            LocalDate date,
-            String content,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            String status) {
-        this.id = id;
-        this.userId = userId;
-        this.blockId = blockId;
-        this.seatId = seatId;
-        this.rowId = rowId;
-        this.seatNumber = seatNumber;
-        this.date = date;
-        this.content = content;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.status = status;
-    }
+    private final LocalDateTime deletedAt;
 }

--- a/domain/src/main/java/org/depromeet/spot/domain/review/Review.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/review/Review.java
@@ -11,6 +11,7 @@ public class Review {
 
     private final Long id;
     private final Long userId;
+    private final Long stadiumId;
     private final Long blockId;
     private final Long seatId;
     private final Long rowId;

--- a/domain/src/main/java/org/depromeet/spot/domain/review/Review.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/review/Review.java
@@ -1,6 +1,7 @@
 package org.depromeet.spot.domain.review;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -21,4 +22,6 @@ public class Review {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
     private final LocalDateTime deletedAt;
+    private final List<ReviewImage> images;
+    private final List<ReviewKeyword> keywords;
 }

--- a/domain/src/main/java/org/depromeet/spot/domain/review/ReviewImage.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/review/ReviewImage.java
@@ -2,8 +2,10 @@ package org.depromeet.spot.domain.review;
 
 import java.time.LocalDateTime;
 
+import lombok.Builder;
 import lombok.Getter;
 
+@Builder
 @Getter
 public class ReviewImage {
 
@@ -11,13 +13,5 @@ public class ReviewImage {
     private final Long reviewId;
     private final String url;
     private final LocalDateTime createdAt;
-    private final String status;
-
-    public ReviewImage(Long id, Long reviewId, String url, LocalDateTime createdAt, String status) {
-        this.id = id;
-        this.reviewId = reviewId;
-        this.url = url;
-        this.createdAt = createdAt;
-        this.status = status;
-    }
+    private final LocalDateTime deletedAt;
 }

--- a/domain/src/main/java/org/depromeet/spot/domain/review/ReviewKeyword.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/review/ReviewKeyword.java
@@ -1,7 +1,9 @@
 package org.depromeet.spot.domain.review;
 
+import lombok.Builder;
 import lombok.Getter;
 
+@Builder
 @Getter
 public class ReviewKeyword {
 
@@ -9,11 +11,4 @@ public class ReviewKeyword {
     private final Long reviewId;
     private final Long keywordId;
     private final Boolean isPositive;
-
-    public ReviewKeyword(Long id, Long reviewId, Long keywordId, Boolean isPositive) {
-        this.id = id;
-        this.reviewId = reviewId;
-        this.keywordId = keywordId;
-        this.isPositive = isPositive;
-    }
 }

--- a/domain/src/main/java/org/depromeet/spot/domain/review/ReviewListResult.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/review/ReviewListResult.java
@@ -1,0 +1,10 @@
+package org.depromeet.spot.domain.review;
+
+import java.util.List;
+
+public record ReviewListResult(
+        List<Review> reviews,
+        List<KeywordCount> topKeywords,
+        int totalCount,
+        int offset,
+        int limit) {}

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/block/entity/BlockTopKeywordEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/block/entity/BlockTopKeywordEntity.java
@@ -2,23 +2,19 @@ package org.depromeet.spot.jpa.block.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.block.BlockTopKeyword;
+import org.depromeet.spot.jpa.common.entity.BaseEntity;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "block_top_keywords")
 @NoArgsConstructor
-public class BlockTopKeywordEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
+@AllArgsConstructor
+public class BlockTopKeywordEntity extends BaseEntity {
 
     @Column(name = "block_id", nullable = false)
     private Long blockId;
@@ -29,22 +25,19 @@ public class BlockTopKeywordEntity {
     @Column(name = "count", nullable = false)
     private Long count;
 
-    public BlockTopKeywordEntity(Long id, Long blockId, Long keywordId, Long count) {
-        this.id = id;
-        this.blockId = blockId;
-        this.keywordId = keywordId;
-        this.count = count;
-    }
-
     public static BlockTopKeywordEntity from(BlockTopKeyword blockTopKeyword) {
         return new BlockTopKeywordEntity(
-                blockTopKeyword.getId(),
                 blockTopKeyword.getBlockId(),
                 blockTopKeyword.getKeywordId(),
                 blockTopKeyword.getCount());
     }
 
     public BlockTopKeyword toDomain() {
-        return new BlockTopKeyword(id, blockId, keywordId, count);
+        return BlockTopKeyword.builder()
+                .id(this.getId())
+                .blockId(blockId)
+                .keywordId(keywordId)
+                .count(count)
+                .build();
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/common/BaseEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/common/BaseEntity.java
@@ -1,0 +1,64 @@
+package org.depromeet.spot.jpa.common.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+
+import org.hibernate.annotations.Where;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@MappedSuperclass
+@AllArgsConstructor
+@Where(clause = "deleted_at is null")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BaseEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(updatable = false, name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return null != this.deletedAt;
+    }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/KeywordEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/KeywordEntity.java
@@ -2,37 +2,28 @@ package org.depromeet.spot.jpa.review.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.review.Keyword;
+import org.depromeet.spot.jpa.common.entity.BaseEntity;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "keywords")
 @NoArgsConstructor
-public class KeywordEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
+@AllArgsConstructor
+public class KeywordEntity extends BaseEntity {
 
     @Column(name = "content", nullable = false, length = 50)
     private String content;
 
-    public KeywordEntity(Long id, String content) {
-        this.id = id;
-        this.content = content;
-    }
-
     public static KeywordEntity from(Keyword keyword) {
-        return new KeywordEntity(keyword.getId(), keyword.getContent());
+        return new KeywordEntity(keyword.getContent());
     }
 
     public Keyword toDomain() {
-        return new Keyword(id, content);
+        return Keyword.builder().id(this.getId()).content(content).build();
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/ReviewEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/ReviewEntity.java
@@ -1,110 +1,57 @@
 package org.depromeet.spot.jpa.review.entity;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.jpa.common.entity.BaseEntity;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "reviews")
 @NoArgsConstructor
-public class ReviewEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
+@AllArgsConstructor
+public class ReviewEntity extends BaseEntity {
 
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name = "block_id", nullable = false)
-    private Long blockId;
-
-    @Column(name = "seat_id", nullable = false)
-    private Long seatId;
-
-    @Column(name = "row_id", nullable = false)
-    private Long rowId;
-
     @Column(name = "seat_number", nullable = false)
     private Long seatNumber;
 
-    @Column(name = "date", nullable = false)
-    private LocalDate date;
+    @Column(name = "dateTime", nullable = false)
+    private LocalDateTime dateTime;
 
     @Column(name = "content", length = 300)
     private String content;
 
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
-
-    @Column(name = "status", nullable = false, length = 15)
-    private String status;
-
-    public ReviewEntity(
-            Long id,
-            Long userId,
-            Long blockId,
-            Long seatId,
-            Long rowId,
-            Long seatNumber,
-            LocalDate date,
-            String content,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            String status) {
-        this.id = id;
-        this.userId = userId;
-        this.blockId = blockId;
-        this.seatId = seatId;
-        this.rowId = rowId;
-        this.seatNumber = seatNumber;
-        this.date = date;
-        this.content = content;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.status = status;
-    }
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
     public static ReviewEntity from(Review review) {
         return new ReviewEntity(
-                review.getId(),
                 review.getUserId(),
-                review.getBlockId(),
-                review.getSeatId(),
-                review.getRowId(),
                 review.getSeatNumber(),
-                review.getDate(),
+                review.getDateTime(),
                 review.getContent(),
-                review.getCreatedAt(),
-                review.getUpdatedAt(),
-                review.getStatus());
+                review.getDeletedAt());
     }
 
     public Review toDomain() {
-        return new Review(
-                id,
-                userId,
-                blockId,
-                seatId,
-                rowId,
-                seatNumber,
-                date,
-                content,
-                createdAt,
-                updatedAt,
-                status);
+        return Review.builder()
+                .id(this.getId())
+                .userId(userId)
+                .seatNumber(seatNumber)
+                .dateTime(dateTime)
+                .content(content)
+                .createdAt(this.getCreatedAt())
+                .updatedAt(this.getUpdatedAt())
+                .deletedAt(deletedAt)
+                .build();
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/ReviewEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/ReviewEntity.java
@@ -21,6 +21,15 @@ public class ReviewEntity extends BaseEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
+    @Column(name = "stadium_id", nullable = false)
+    private Long stadiumId;
+
+    @Column(name = "block_id", nullable = false)
+    private Long blockId;
+
+    @Column(name = "row_id", nullable = false)
+    private Long rowId;
+
     @Column(name = "seat_number", nullable = false)
     private Long seatNumber;
 
@@ -36,6 +45,9 @@ public class ReviewEntity extends BaseEntity {
     public static ReviewEntity from(Review review) {
         return new ReviewEntity(
                 review.getUserId(),
+                review.getStadiumId(),
+                review.getBlockId(),
+                review.getRowId(),
                 review.getSeatNumber(),
                 review.getDateTime(),
                 review.getContent(),
@@ -46,6 +58,9 @@ public class ReviewEntity extends BaseEntity {
         return Review.builder()
                 .id(this.getId())
                 .userId(userId)
+                .stadiumId(stadiumId)
+                .blockId(blockId)
+                .rowId(rowId)
                 .seatNumber(seatNumber)
                 .dateTime(dateTime)
                 .content(content)

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/ReviewImageEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/ReviewImageEntity.java
@@ -4,23 +4,19 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.review.ReviewImage;
+import org.depromeet.spot.jpa.common.entity.BaseEntity;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "review_images")
 @NoArgsConstructor
-public class ReviewImageEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
+@AllArgsConstructor
+public class ReviewImageEntity extends BaseEntity {
 
     @Column(name = "review_id", nullable = false)
     private Long reviewId;
@@ -28,31 +24,21 @@ public class ReviewImageEntity {
     @Column(name = "url", nullable = false, length = 255)
     private String url;
 
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "status", nullable = false, length = 15)
-    private String status;
-
-    public ReviewImageEntity(
-            Long id, Long reviewId, String url, LocalDateTime createdAt, String status) {
-        this.id = id;
-        this.reviewId = reviewId;
-        this.url = url;
-        this.createdAt = createdAt;
-        this.status = status;
-    }
+    @Column(name = "deleted_at", nullable = false, length = 15)
+    private LocalDateTime deletedAt;
 
     public static ReviewImageEntity from(ReviewImage reviewImage) {
         return new ReviewImageEntity(
-                reviewImage.getId(),
-                reviewImage.getReviewId(),
-                reviewImage.getUrl(),
-                reviewImage.getCreatedAt(),
-                reviewImage.getStatus());
+                reviewImage.getReviewId(), reviewImage.getUrl(), reviewImage.getDeletedAt());
     }
 
     public ReviewImage toDomain() {
-        return new ReviewImage(id, reviewId, url, createdAt, status);
+        return ReviewImage.builder()
+                .id(this.getId())
+                .reviewId(reviewId)
+                .url(url)
+                .createdAt(this.getCreatedAt())
+                .deletedAt(deletedAt)
+                .build();
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/ReviewImageEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/ReviewImageEntity.java
@@ -24,7 +24,7 @@ public class ReviewImageEntity extends BaseEntity {
     @Column(name = "url", nullable = false, length = 255)
     private String url;
 
-    @Column(name = "deleted_at", nullable = false, length = 15)
+    @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
     public static ReviewImageEntity from(ReviewImage reviewImage) {

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/ReviewKeywordEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/entity/ReviewKeywordEntity.java
@@ -2,23 +2,19 @@ package org.depromeet.spot.jpa.review.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.review.ReviewKeyword;
+import org.depromeet.spot.jpa.common.entity.BaseEntity;
 
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "review_keywords")
 @NoArgsConstructor
-public class ReviewKeywordEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
-    private Long id;
+@AllArgsConstructor
+public class ReviewKeywordEntity extends BaseEntity {
 
     @Column(name = "review_id", nullable = false)
     private Long reviewId;
@@ -29,22 +25,19 @@ public class ReviewKeywordEntity {
     @Column(name = "is_positive", nullable = false)
     private Boolean isPositive;
 
-    public ReviewKeywordEntity(Long id, Long reviewId, Long keywordId, Boolean isPositive) {
-        this.id = id;
-        this.reviewId = reviewId;
-        this.keywordId = keywordId;
-        this.isPositive = isPositive;
-    }
-
     public static ReviewKeywordEntity from(ReviewKeyword reviewKeyword) {
         return new ReviewKeywordEntity(
-                reviewKeyword.getId(),
                 reviewKeyword.getReviewId(),
                 reviewKeyword.getKeywordId(),
                 reviewKeyword.getIsPositive());
     }
 
     public ReviewKeyword toDomain() {
-        return new ReviewKeyword(id, reviewId, keywordId, isPositive);
+        return ReviewKeyword.builder()
+                .id(this.getId())
+                .reviewId(reviewId)
+                .keywordId(keywordId)
+                .isPositive(isPositive)
+                .build();
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewCustomRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewCustomRepository.java
@@ -1,0 +1,107 @@
+package org.depromeet.spot.jpa.review.repository;
+
+import static org.depromeet.spot.jpa.review.entity.QKeywordEntity.keywordEntity;
+import static org.depromeet.spot.jpa.review.entity.QReviewEntity.reviewEntity;
+import static org.depromeet.spot.jpa.review.entity.QReviewImageEntity.reviewImageEntity;
+import static org.depromeet.spot.jpa.review.entity.QReviewKeywordEntity.reviewKeywordEntity;
+
+import java.util.List;
+
+import org.depromeet.spot.domain.review.KeywordCount;
+import org.depromeet.spot.jpa.review.entity.ReviewEntity;
+import org.depromeet.spot.jpa.review.entity.ReviewImageEntity;
+import org.depromeet.spot.jpa.review.entity.ReviewKeywordEntity;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<ReviewEntity> findByBlockIdWithFilters(
+            Long stadiumId, Long blockId, Long rowId, Long seatNumber, int offset, int limit) {
+        return queryFactory
+                .selectFrom(reviewEntity)
+                .where(
+                        reviewEntity
+                                .stadiumId
+                                .eq(stadiumId)
+                                .and(reviewEntity.blockId.eq(blockId))
+                                .and(rowId != null ? reviewEntity.rowId.eq(rowId) : null)
+                                .and(
+                                        seatNumber != null
+                                                ? reviewEntity.seatNumber.eq(seatNumber)
+                                                : null)
+                                .and(reviewEntity.deletedAt.isNull()))
+                .orderBy(reviewEntity.createdAt.desc())
+                .offset(offset)
+                .limit(limit)
+                .fetch();
+    }
+
+    public long countByBlockIdWithFilters(
+            Long stadiumId, Long blockId, Long rowId, Long seatNumber) {
+        return queryFactory
+                .selectFrom(reviewEntity)
+                .where(
+                        reviewEntity
+                                .stadiumId
+                                .eq(stadiumId)
+                                .and(reviewEntity.blockId.eq(blockId))
+                                .and(rowId != null ? reviewEntity.rowId.eq(rowId) : null)
+                                .and(
+                                        seatNumber != null
+                                                ? reviewEntity.seatNumber.eq(seatNumber)
+                                                : null)
+                                .and(reviewEntity.deletedAt.isNull()))
+                .fetchCount();
+    }
+
+    public List<KeywordCount> findTopKeywordsByBlockId(Long stadiumId, Long blockId, int limit) {
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                KeywordCount.class,
+                                keywordEntity.content,
+                                reviewKeywordEntity.count().as("count")))
+                .from(reviewKeywordEntity)
+                .join(keywordEntity)
+                .on(reviewKeywordEntity.keywordId.eq(keywordEntity.id))
+                .join(reviewEntity)
+                .on(reviewKeywordEntity.reviewId.eq(reviewEntity.id))
+                .where(
+                        reviewEntity
+                                .stadiumId
+                                .eq(stadiumId)
+                                .and(reviewEntity.blockId.eq(blockId))
+                                .and(reviewEntity.deletedAt.isNull()))
+                .groupBy(keywordEntity.id, keywordEntity.content)
+                .orderBy(reviewKeywordEntity.count().desc())
+                .limit(limit)
+                .fetch();
+    }
+
+    public List<ReviewImageEntity> findImagesByReviewId(Long reviewId) {
+        return queryFactory
+                .selectFrom(reviewImageEntity)
+                .where(
+                        reviewImageEntity
+                                .reviewId
+                                .eq(reviewId)
+                                .and(reviewImageEntity.deletedAt.isNull()))
+                .fetch();
+    }
+
+    public List<ReviewKeywordEntity> findKeywordsByReviewId(Long reviewId) {
+        return queryFactory
+                .selectFrom(reviewKeywordEntity)
+                .where(reviewKeywordEntity.reviewId.eq(reviewId))
+                .fetch();
+    }
+}

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewRepositoryImpl.java
@@ -1,0 +1,72 @@
+package org.depromeet.spot.jpa.review.repository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.depromeet.spot.domain.review.KeywordCount;
+import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.domain.review.ReviewImage;
+import org.depromeet.spot.domain.review.ReviewKeyword;
+import org.depromeet.spot.jpa.review.entity.ReviewEntity;
+import org.depromeet.spot.jpa.review.entity.ReviewImageEntity;
+import org.depromeet.spot.jpa.review.entity.ReviewKeywordEntity;
+import org.depromeet.spot.usecase.port.out.review.ReviewRepository;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl implements ReviewRepository {
+    private final ReviewCustomRepository reviewCustomRepository;
+
+    @Override
+    public List<Review> findByBlockId(
+            Long stadiumId, Long blockId, Long rowId, Long seatNumber, int offset, int limit) {
+        List<ReviewEntity> reviews =
+                reviewCustomRepository.findByBlockIdWithFilters(
+                        stadiumId, blockId, rowId, seatNumber, offset, limit);
+        return reviews.stream().map(this::fetchReviewDetails).collect(Collectors.toList());
+    }
+
+    @Override
+    public int countByBlockId(Long stadiumId, Long blockId, Long rowId, Long seatNumber) {
+        return (int)
+                reviewCustomRepository.countByBlockIdWithFilters(
+                        stadiumId, blockId, rowId, seatNumber);
+    }
+
+    @Override
+    public List<KeywordCount> findTopKeywordsByBlockId(Long stadiumId, Long blockId, int limit) {
+        return reviewCustomRepository.findTopKeywordsByBlockId(stadiumId, blockId, limit);
+    }
+
+    private Review fetchReviewDetails(ReviewEntity reviewEntity) {
+        List<ReviewImage> images =
+                reviewCustomRepository.findImagesByReviewId(reviewEntity.getId()).stream()
+                        .map(ReviewImageEntity::toDomain)
+                        .collect(Collectors.toList());
+
+        List<ReviewKeyword> keywords =
+                reviewCustomRepository.findKeywordsByReviewId(reviewEntity.getId()).stream()
+                        .map(ReviewKeywordEntity::toDomain)
+                        .collect(Collectors.toList());
+
+        Review review = reviewEntity.toDomain();
+        return Review.builder()
+                .id(review.getId())
+                .userId(review.getUserId())
+                .stadiumId(review.getStadiumId())
+                .blockId(review.getBlockId())
+                .rowId(review.getRowId())
+                .seatNumber(review.getSeatNumber())
+                .dateTime(review.getDateTime())
+                .content(review.getContent())
+                .createdAt(review.getCreatedAt())
+                .updatedAt(review.getUpdatedAt())
+                .deletedAt(review.getDeletedAt())
+                .images(images)
+                .keywords(keywords)
+                .build();
+    }
+}

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewRepositoryImpl.java
@@ -3,6 +3,8 @@ package org.depromeet.spot.jpa.review.repository;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.depromeet.spot.common.exception.review.ReviewException;
+import org.depromeet.spot.common.exception.review.ReviewException.InvalidReviewDataException;
 import org.depromeet.spot.domain.review.KeywordCount;
 import org.depromeet.spot.domain.review.Review;
 import org.depromeet.spot.domain.review.ReviewImage;
@@ -26,6 +28,10 @@ public class ReviewRepositoryImpl implements ReviewRepository {
         List<ReviewEntity> reviews =
                 reviewCustomRepository.findByBlockIdWithFilters(
                         stadiumId, blockId, rowId, seatNumber, offset, limit);
+        if (reviews.isEmpty()) {
+            throw new ReviewException.ReviewNotFoundException(
+                    "No review found for blockId:" + blockId);
+        }
         return reviews.stream().map(this::fetchReviewDetails).collect(Collectors.toList());
     }
 
@@ -53,6 +59,10 @@ public class ReviewRepositoryImpl implements ReviewRepository {
                         .collect(Collectors.toList());
 
         Review review = reviewEntity.toDomain();
+        if (review == null) {
+            throw new InvalidReviewDataException(
+                    "Failed to convert entity to domain for reviewId: " + reviewEntity.getId());
+        }
         return Review.builder()
                 .id(review.getId())
                 .userId(review.getUserId())

--- a/infrastructure/jpa/src/main/resources/data.sql
+++ b/infrastructure/jpa/src/main/resources/data.sql
@@ -1,8 +1,8 @@
 -- Stadiums
 INSERT INTO stadiums (id, name, main_image, seating_chart_image, labeled_seating_chart_image, is_active)
-VALUES (1, '잠실 야구 경기장', 'main_image_a.jpg', 'seating_chart_a.jpg', 'labeled_seating_chart_a.jpg', true),
-       (2, '김포 야구 경기장', 'main_image_b.jpg', 'seating_chart_b.jpg', 'labeled_seating_chart_b.jpg', true),
-       (3, '부산 야구 경기장', 'main_image_c.jpg', 'seating_chart_c.jpg', 'labeled_seating_chart_c.jpg', false);
+VALUES (1, '잠실 야구 경기장', 'main_image_a.jpg', 'seating_chart_a.jpg', 'labeled_seating_chart_a.jpg', 1),
+       (2, '김포 야구 경기장', 'main_image_b.jpg', 'seating_chart_b.jpg', 'labeled_seating_chart_b.jpg', 1),
+       (3, '부산 야구 경기장', 'main_image_c.jpg', 'seating_chart_c.jpg', 'labeled_seating_chart_c.jpg', 0);
 
 -- Baseball Teams
 INSERT INTO baseball_teams (id, name, alias, logo, red, green, blue)
@@ -22,3 +22,38 @@ INSERT INTO sections (id, stadium_id, name, alias, red, green, blue)
 VALUES (1, 1, '오렌지석', '응원석', 255, 255, 255),
        (2, 1, '네이비석', '프리미엄석', 100, 100, 100),
        (3, 1, '레드석', null, 100, 0, 0);
+
+-- Reviews
+INSERT INTO reviews (id, user_id, stadium_id, block_id, row_id, seat_number, date_time, content, created_at, updated_at)
+VALUES
+(1, 1, 1, 1, 1, 10, '2023-07-15 14:00:00', '좋은 경기였습니다!', '2023-07-15 18:00:00', '2023-07-15 18:00:00'),
+(2, 2, 1, 1, 2, 15, '2023-07-16 15:00:00', '시야가 좋았어요', '2023-07-16 19:00:00', '2023-07-16 19:00:00'),
+(3, 3, 1, 2, 1, 5, '2023-07-17 16:00:00', '다음에 또 오고 싶어요', '2023-07-17 20:00:00', '2023-07-17 20:00:00');
+
+-- Review Images
+INSERT INTO review_images (id, review_id, url, created_at)
+VALUES (1, 1, 'review1_image1.jpg', '2023-07-15 18:00:00'),
+       (2, 1, 'review1_image2.jpg', '2023-07-15 18:00:00'),
+       (3, 2, 'review2_image1.jpg', '2023-07-16 19:00:00'),
+       (4, 3, 'review3_image1.jpg', '2023-07-17 20:00:00');
+
+-- Keywords
+INSERT INTO keywords (id, content)
+VALUES (1, '좋아요'),
+       (2, '시야 좋음'),
+       (3, '재방문 의사'),
+       (4, '편안함');
+
+-- Review Keywords
+INSERT INTO review_keywords (id, review_id, keyword_id, is_positive)
+VALUES (1, 1, 1, 1),
+       (2, 1, 4, 1),
+       (3, 2, 2, 1),
+       (4, 3, 3, 1);
+
+-- Block Top Keywords
+INSERT INTO block_top_keywords (id, block_id, keyword_id, count)
+VALUES (1, 1, 1, 10),
+       (2, 1, 2, 8),
+       (3, 2, 3, 5),
+       (4, 2, 4, 3);

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReviewReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReviewReadUsecase.java
@@ -1,0 +1,8 @@
+package org.depromeet.spot.usecase.port.in.review;
+
+import org.depromeet.spot.domain.review.ReviewListResult;
+
+public interface ReviewReadUsecase {
+    ReviewListResult findReviewsByBlockId(
+            Long stadiumId, Long blockId, Long rowId, Long seatNumber, int offset, int limit);
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewRepository.java
@@ -1,0 +1,15 @@
+package org.depromeet.spot.usecase.port.out.review;
+
+import java.util.List;
+
+import org.depromeet.spot.domain.review.KeywordCount;
+import org.depromeet.spot.domain.review.Review;
+
+public interface ReviewRepository {
+    List<Review> findByBlockId(
+            Long stadiumId, Long blockId, Long rowId, Long seatNumber, int offset, int limit);
+
+    int countByBlockId(Long stadiumId, Long blockId, Long rowId, Long seatNumber);
+
+    List<KeywordCount> findTopKeywordsByBlockId(Long stadiumId, Long blockId, int limit);
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReviewReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReviewReadService.java
@@ -1,0 +1,31 @@
+package org.depromeet.spot.usecase.service.review;
+
+import java.util.List;
+
+import org.depromeet.spot.domain.review.KeywordCount;
+import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.domain.review.ReviewListResult;
+import org.depromeet.spot.usecase.port.in.review.ReviewReadUsecase;
+import org.depromeet.spot.usecase.port.out.review.ReviewRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewReadService implements ReviewReadUsecase {
+    private final ReviewRepository reviewRepository;
+
+    @Override
+    public ReviewListResult findReviewsByBlockId(
+            Long stadiumId, Long blockId, Long rowId, Long seatNumber, int offset, int limit) {
+        List<Review> reviews =
+                reviewRepository.findByBlockId(
+                        stadiumId, blockId, rowId, seatNumber, offset, limit);
+        int totalCount = reviewRepository.countByBlockId(stadiumId, blockId, rowId, seatNumber);
+        List<KeywordCount> topKeywords =
+                reviewRepository.findTopKeywordsByBlockId(stadiumId, blockId, 5);
+
+        return new ReviewListResult(reviews, topKeywords, totalCount, offset, limit);
+    }
+}

--- a/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeReviewRepository.java
+++ b/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeReviewRepository.java
@@ -1,0 +1,90 @@
+package org.depromeet.spot.usecase.service.fake;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.depromeet.spot.common.exception.review.ReviewException;
+import org.depromeet.spot.domain.review.KeywordCount;
+import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.domain.review.ReviewKeyword;
+import org.depromeet.spot.usecase.port.out.review.ReviewRepository;
+
+public class FakeReviewRepository implements ReviewRepository {
+
+    private final List<Review> data = new ArrayList<>();
+
+    @Override
+    public List<Review> findByBlockId(
+            Long stadiumId, Long blockId, Long rowId, Long seatNumber, int offset, int limit) {
+        List<Review> filteredReviews =
+                data.stream()
+                        .filter(
+                                review ->
+                                        review.getStadiumId().equals(stadiumId)
+                                                && review.getBlockId().equals(blockId))
+                        .filter(review -> rowId == null || review.getRowId().equals(rowId))
+                        .filter(
+                                review ->
+                                        seatNumber == null
+                                                || review.getSeatNumber().equals(seatNumber))
+                        .skip(offset)
+                        .limit(limit)
+                        .collect(Collectors.toList());
+
+        if (filteredReviews.isEmpty()) {
+            throw new ReviewException.ReviewNotFoundException(
+                    "No review found for blockId:" + blockId);
+        }
+
+        return filteredReviews;
+    }
+
+    @Override
+    public int countByBlockId(Long stadiumId, Long blockId, Long rowId, Long seatNumber) {
+        return (int)
+                data.stream()
+                        .filter(
+                                review ->
+                                        review.getStadiumId().equals(stadiumId)
+                                                && review.getBlockId().equals(blockId))
+                        .filter(review -> rowId == null || review.getRowId().equals(rowId))
+                        .filter(
+                                review ->
+                                        seatNumber == null
+                                                || review.getSeatNumber().equals(seatNumber))
+                        .count();
+    }
+
+    @Override
+    public List<KeywordCount> findTopKeywordsByBlockId(Long stadiumId, Long blockId, int limit) {
+        Map<Long, Long> keywordCounts =
+                data.stream()
+                        .filter(
+                                review ->
+                                        review.getStadiumId().equals(stadiumId)
+                                                && review.getBlockId().equals(blockId))
+                        .flatMap(
+                                review ->
+                                        review.getKeywords() != null
+                                                ? review.getKeywords().stream()
+                                                : Stream.empty())
+                        .collect(
+                                Collectors.groupingBy(
+                                        ReviewKeyword::getKeywordId, Collectors.counting()));
+
+        return keywordCounts.entrySet().stream()
+                .map(entry -> new KeywordCount(entry.getKey().toString(), entry.getValue()))
+                .sorted(Comparator.comparing(KeywordCount::count).reversed())
+                .limit(limit)
+                .collect(Collectors.toList());
+    }
+
+    public void save(Review review) {
+        data.add(review);
+    }
+
+    public void clear() {
+        data.clear();
+    }
+}

--- a/usecase/src/test/java/org/depromeet/spot/usecase/service/review/ReviewReadServiceTest.java
+++ b/usecase/src/test/java/org/depromeet/spot/usecase/service/review/ReviewReadServiceTest.java
@@ -1,0 +1,118 @@
+package org.depromeet.spot.usecase.service.review;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Collections;
+
+import org.depromeet.spot.common.exception.review.ReviewException;
+import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.domain.review.ReviewKeyword;
+import org.depromeet.spot.domain.review.ReviewListResult;
+import org.depromeet.spot.usecase.service.fake.FakeReviewRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ReviewReadServiceTest {
+
+    private ReviewReadService reviewReadService;
+    private FakeReviewRepository fakeReviewRepository;
+
+    private ReviewKeyword createReviewKeyword(
+            Long id, Long reviewId, Long keywordId, Boolean isPositive) {
+        return ReviewKeyword.builder()
+                .id(id)
+                .reviewId(reviewId)
+                .keywordId(keywordId)
+                .isPositive(isPositive)
+                .build();
+    }
+
+    @BeforeEach
+    void setUp() {
+        fakeReviewRepository = new FakeReviewRepository();
+        reviewReadService = new ReviewReadService(fakeReviewRepository);
+    }
+
+    @Test
+    void findReviewsByBlockId는_블록별_리뷰를_정상적으로_반환한다() {
+        // Given
+        Review review1 =
+                Review.builder()
+                        .id(1L)
+                        .stadiumId(1L)
+                        .blockId(1L)
+                        .rowId(1L)
+                        .seatNumber(1L)
+                        .content("Great game!")
+                        .keywords(Collections.singletonList(createReviewKeyword(1L, 1L, 1L, true)))
+                        .build();
+        Review review2 =
+                Review.builder()
+                        .id(2L)
+                        .stadiumId(1L)
+                        .blockId(1L)
+                        .rowId(2L)
+                        .seatNumber(2L)
+                        .content("Amazing view!")
+                        .keywords(
+                                Collections.singletonList(
+                                        createReviewKeyword(2L, 2L, 2L, true))) // 다른 keywordId 사용
+                        .build();
+        fakeReviewRepository.save(review1);
+        fakeReviewRepository.save(review2);
+
+        // When
+        ReviewListResult result = reviewReadService.findReviewsByBlockId(1L, 1L, null, null, 0, 10);
+
+        // Then
+        assertEquals(2, result.reviews().size());
+        assertEquals(2, result.totalCount());
+        assertEquals(2, result.topKeywords().size());
+    }
+
+    @Test
+    void findReviewsByBlockId는_조회된_리뷰가_없을_시_NotFoundException_반환한다() {
+        // Given
+        Long nonExistentStadiumId = 999L;
+        Long nonExistentBlockId = 999L;
+
+        // When & Then
+        assertThatThrownBy(
+                        () ->
+                                reviewReadService.findReviewsByBlockId(
+                                        nonExistentStadiumId,
+                                        nonExistentBlockId,
+                                        null,
+                                        null,
+                                        0,
+                                        10))
+                .isInstanceOf(ReviewException.ReviewNotFoundException.class)
+                .hasMessageContaining("No review found for blockId:" + nonExistentBlockId);
+    }
+
+    @Test
+    void findReviewsByBlockId는_offset과_limit로_잘_필터링한다() {
+        // Given
+        for (int i = 0; i < 20; i++) {
+            Review review =
+                    Review.builder()
+                            .id((long) i)
+                            .stadiumId(1L)
+                            .blockId(1L)
+                            .rowId(1L)
+                            .seatNumber((long) i)
+                            .content("Review " + i)
+                            .keywords(Collections.emptyList()) // 빈 리스트로 초기화
+                            .build();
+            fakeReviewRepository.save(review);
+        }
+
+        // When
+        ReviewListResult result = reviewReadService.findReviewsByBlockId(1L, 1L, null, null, 5, 10);
+
+        // Then
+        assertEquals(10, result.reviews().size());
+        assertEquals(20, result.totalCount());
+    }
+}


### PR DESCRIPTION
## 📌 개요 (필수)

- 블록별 리뷰 조회 API 구현

<br>

## 🔨 작업 사항 (필수)

- [블록별 리뷰 조회 API 구현](https://www.notion.so/depromeet/641930b80ff54b0b9609a9621f116079?pvs=4)

0.리뷰쪽 domain에 빌더 적용,  entity에는 base entity 적용
1. 블록별 리뷰 데이터 반환
2. 열,번 필터링 가능
3. offset, limit 방식
4. 404 커스텀 예외, 400 bad request 커스텀 예외 구현
5. 테스트 코드 작성


<br>

## ⚡️ 관심 리뷰 (선택)

- 헥사고날 원칙이 잘 지켜졌는지, 유스케이스에서는 response dto를 몰라야하니까 domain에 응답형태의 domain class를 만들어줬는데 더 좋은 방법이 있을까??


<br>

## 🌱 연관 내용 (선택)

- 모킹 진짜 죽을 것 같아요 테스트 코드 작성하는데 3시간 걸렸습니다..
- 코드가 양이 많네요ㅠㅠ 죄송합니다..

<br>

## 💻 실행 화면 (필수)

### 404

<img width="1480" alt="image" src="https://github.com/user-attachments/assets/c5cfffb3-3932-423d-8fdf-8545c8e84ab9">

### 200

<img width="1411" alt="image" src="https://github.com/user-attachments/assets/ec98be04-4af2-4466-8b55-c5903db75799">

### 테스트 결과

![image](https://github.com/user-attachments/assets/dc51a270-1b4c-42d7-af04-0182e18e6ab8)
