### PR TITLE
[BSVR-91] 경기장 등록 API & 이미지 업로드 컴포넌트

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/media/MediaController.java
+++ b/application/src/main/java/org/depromeet/spot/application/media/MediaController.java
@@ -36,15 +36,4 @@ public class MediaController {
         String presignedUrl = createPresignedUrlPort.forReview(memberId, command);
         return new MediaUrlResponse(presignedUrl);
     }
-
-    @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping(value = "/stadiums/images")
-    @Operation(summary = "공연장 이미지 업로드 url을 생성합니다.")
-    public MediaUrlResponse createStadiumSeatUploadUrl(
-            @RequestBody @Valid CreatePresignedUrlRequest request) {
-        PresignedUrlRequest command =
-                new PresignedUrlRequest(request.fileExtension(), request.property());
-        String presignedUrl = createPresignedUrlPort.forStadiumSeat(command);
-        return new MediaUrlResponse(presignedUrl);
-    }
 }

--- a/application/src/main/java/org/depromeet/spot/application/stadium/CreateStadiumController.java
+++ b/application/src/main/java/org/depromeet/spot/application/stadium/CreateStadiumController.java
@@ -1,0 +1,47 @@
+package org.depromeet.spot.application.stadium;
+
+import org.depromeet.spot.application.stadium.dto.response.StadiumResponse;
+import org.depromeet.spot.domain.stadium.Stadium;
+import org.depromeet.spot.usecase.port.in.stadium.CreateStadiumUsecase;
+import org.depromeet.spot.usecase.port.in.stadium.CreateStadiumUsecase.CreateStadiumReq;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@Tag(name = "경기장")
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/stadiums")
+public class CreateStadiumController {
+
+    private final CreateStadiumUsecase createStadiumUsecase;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "신규 야구 경기장을 등록한다.")
+    public StadiumResponse create(
+            @RequestParam("name") String name,
+            @RequestParam("mainImage") MultipartFile mainImage,
+            @RequestParam("seatingChartImage") MultipartFile seatingChartImage,
+            @RequestParam("labeledSeatingChartImage") MultipartFile labeledSeatingChartImage,
+            @RequestParam("isActive") boolean isActive) {
+        CreateStadiumReq req =
+                CreateStadiumReq.builder()
+                        .name(name)
+                        .mainImage(mainImage)
+                        .seatingChartImage(seatingChartImage)
+                        .labeledSeatingChartImage(labeledSeatingChartImage)
+                        .isActive(isActive)
+                        .build();
+        Stadium stadium = createStadiumUsecase.create(req);
+        return StadiumResponse.from(stadium);
+    }
+}

--- a/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumResponse.java
@@ -18,9 +18,9 @@ public record StadiumResponse(
                 .id(stadium.getId())
                 .name(stadium.getName())
                 .mainImage(stadium.getMainImage())
-                .seatingChartImage(builder().seatingChartImage)
-                .labeledSeatingChartImage(builder().labeledSeatingChartImage)
-                .isActive(builder().isActive)
+                .seatingChartImage(stadium.getSeatingChartImage())
+                .labeledSeatingChartImage(stadium.getLabeledSeatingChartImage())
+                .isActive(stadium.isActive())
                 .build();
     }
 }

--- a/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumResponse.java
@@ -1,0 +1,26 @@
+package org.depromeet.spot.application.stadium.dto.response;
+
+import org.depromeet.spot.domain.stadium.Stadium;
+
+import lombok.Builder;
+
+@Builder
+public record StadiumResponse(
+        Long id,
+        String name,
+        String mainImage,
+        String seatingChartImage,
+        String labeledSeatingChartImage,
+        boolean isActive) {
+
+    public static StadiumResponse from(Stadium stadium) {
+        return StadiumResponse.builder()
+                .id(stadium.getId())
+                .name(stadium.getName())
+                .mainImage(stadium.getMainImage())
+                .seatingChartImage(builder().seatingChartImage)
+                .labeledSeatingChartImage(builder().labeledSeatingChartImage)
+                .isActive(builder().isActive)
+                .build();
+    }
+}

--- a/common/src/main/java/org/depromeet/spot/common/exception/media/MediaErrorCode.java
+++ b/common/src/main/java/org/depromeet/spot/common/exception/media/MediaErrorCode.java
@@ -13,6 +13,7 @@ public enum MediaErrorCode implements ErrorCode {
     INVALID_STADIUM_MEDIA(HttpStatus.BAD_REQUEST, "ME002", "경기장과 관련된 미디어 파일이 아닙니다."),
     INVALID_REVIEW_MEDIA(HttpStatus.BAD_REQUEST, "ME003", "리뷰와 관련된 미디어 파일이 아닙니다."),
     INVALID_MEDIA(HttpStatus.INTERNAL_SERVER_ERROR, "ME004", "잘못된 미디어 형식입니다."),
+    UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "ME005", "파일 업로드에 실패했습니다."),
     ;
 
     private final HttpStatus status;

--- a/common/src/main/java/org/depromeet/spot/common/exception/media/MediaException.java
+++ b/common/src/main/java/org/depromeet/spot/common/exception/media/MediaException.java
@@ -35,4 +35,10 @@ public abstract class MediaException extends BusinessException {
             super(MediaErrorCode.INVALID_MEDIA);
         }
     }
+
+    public static class UploadFailException extends MediaException {
+        public UploadFailException() {
+            super(MediaErrorCode.UPLOAD_FAIL);
+        }
+    }
 }

--- a/domain/src/main/java/org/depromeet/spot/domain/media/MediaProperty.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/media/MediaProperty.java
@@ -1,7 +1,19 @@
 package org.depromeet.spot.domain.media;
 
+import lombok.Getter;
+
+@Getter
 public enum MediaProperty {
-    REVIEW,
-    STADIUM,
+    REVIEW("review-images"),
+    STADIUM("stadium-images"),
+    STADIUM_SEAT("stadium-seat-charts"),
+    STADIUM_SEAT_LABEL("stadium-seat-label-charts"),
+    TEAM_LOGO("team-logos"),
     ;
+
+    private final String folderName;
+
+    MediaProperty(final String folderName) {
+        this.folderName = folderName;
+    }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/stadium/repository/StadiumRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/stadium/repository/StadiumRepositoryImpl.java
@@ -32,8 +32,8 @@ public class StadiumRepositoryImpl implements StadiumRepository {
 
     @Override
     public Stadium save(Stadium stadium) {
-        // TODO: test를 위해 추가 -> 구장 저장 API 티켓때 구현 예정
-        return null;
+        StadiumEntity entity = stadiumJpaRepository.save(StadiumEntity.from(stadium));
+        return entity.toDomain();
     }
 
     @Override

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/stadium/repository/StadiumRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/stadium/repository/StadiumRepositoryImpl.java
@@ -9,7 +9,9 @@ import org.depromeet.spot.usecase.port.out.stadium.StadiumRepository;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class StadiumRepositoryImpl implements StadiumRepository {

--- a/infrastructure/ncp/build.gradle.kts
+++ b/infrastructure/ncp/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
 
     // spring
     implementation("org.springframework.boot:spring-boot-starter")
+    implementation("org.springframework.boot:spring-boot-starter-web")
 
     // ncp
     implementation("org.springframework.cloud:spring-cloud-starter-aws:_") {

--- a/infrastructure/ncp/src/main/java/org/depromeet/spot/ncp/config/ObjectStorageConfig.java
+++ b/infrastructure/ncp/src/main/java/org/depromeet/spot/ncp/config/ObjectStorageConfig.java
@@ -21,6 +21,7 @@ public class ObjectStorageConfig {
     private final ObjectStorageProperties objectStorageProperties;
     private static final String ENDPOINT = "https://kr.object.ncloudstorage.com";
     private static final String REGION = "kr-standard";
+    public static final String BUCKET_NAME = "spot-image-bucket";
 
     @Bean
     public AmazonS3 getAmazonS3() {

--- a/infrastructure/ncp/src/main/java/org/depromeet/spot/ncp/objectstorage/ImageUploader.java
+++ b/infrastructure/ncp/src/main/java/org/depromeet/spot/ncp/objectstorage/ImageUploader.java
@@ -1,0 +1,85 @@
+package org.depromeet.spot.ncp.objectstorage;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.depromeet.spot.common.exception.media.MediaException.InvalidExtensionException;
+import org.depromeet.spot.common.exception.media.MediaException.UploadFailException;
+import org.depromeet.spot.domain.media.MediaProperty;
+import org.depromeet.spot.domain.media.extension.ImageExtension;
+import org.depromeet.spot.domain.media.extension.StadiumSeatMediaExtension;
+import org.depromeet.spot.ncp.property.ObjectStorageProperties;
+import org.depromeet.spot.usecase.port.out.media.ImageUploadPort;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ImageUploader implements ImageUploadPort {
+
+    private final AmazonS3 amazonS3;
+    private final ObjectStorageProperties objectStorageProperties;
+
+    @Override
+    public String upload(String targetName, MultipartFile file, MediaProperty property) {
+        if (file == null || file.isEmpty()) {
+            return null;
+        }
+
+        final String fileExtension = StringUtils.getFilenameExtension(file.getOriginalFilename());
+        checkValidExtension(fileExtension, property);
+        final String bucketName = objectStorageProperties.bucketName();
+        final String folderName = property.getFolderName();
+        final String fileName = createFileName(targetName, folderName, fileExtension);
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(file.getSize());
+        objectMetadata.setContentType(file.getContentType());
+
+        try (InputStream inputStream = file.getInputStream()) {
+            amazonS3.putObject(
+                    new PutObjectRequest("spot-image-bucket", fileName, inputStream, objectMetadata)
+                            .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            throw new UploadFailException();
+        }
+
+        return amazonS3.getUrl("spot-image-bucket", fileName).toString();
+    }
+
+    private void checkValidExtension(final String fileExtension, MediaProperty property) {
+        if (property == MediaProperty.STADIUM_SEAT
+                || property == MediaProperty.STADIUM_SEAT_LABEL) {
+            checkValidSeatExtension(fileExtension);
+        } else {
+            checkValidImageExtension(fileExtension);
+        }
+    }
+
+    private void checkValidSeatExtension(final String fileExtension) {
+        if (!StadiumSeatMediaExtension.isValid(fileExtension)) {
+            throw new InvalidExtensionException(fileExtension);
+        }
+    }
+
+    private void checkValidImageExtension(final String fileExtension) {
+        if (!ImageExtension.isValid(fileExtension)) {
+            throw new InvalidExtensionException(fileExtension);
+        }
+    }
+
+    private String createFileName(
+            final String targetName, final String folderName, final String fileExtension) {
+        return folderName + "/" + targetName + "." + fileExtension;
+    }
+}

--- a/infrastructure/ncp/src/main/java/org/depromeet/spot/ncp/objectstorage/PresignedUrlGenerator.java
+++ b/infrastructure/ncp/src/main/java/org/depromeet/spot/ncp/objectstorage/PresignedUrlGenerator.java
@@ -5,12 +5,9 @@ import java.util.Date;
 
 import org.depromeet.spot.common.exception.media.MediaException.InvalidExtensionException;
 import org.depromeet.spot.common.exception.media.MediaException.InvalidReviewMediaException;
-import org.depromeet.spot.common.exception.media.MediaException.InvalidStadiumMediaException;
 import org.depromeet.spot.domain.media.MediaProperty;
 import org.depromeet.spot.domain.media.extension.ImageExtension;
-import org.depromeet.spot.domain.media.extension.StadiumSeatMediaExtension;
 import org.depromeet.spot.ncp.property.ReviewStorageProperties;
-import org.depromeet.spot.ncp.property.StadiumStorageProperties;
 import org.depromeet.spot.usecase.port.out.media.CreatePresignedUrlPort;
 import org.springframework.stereotype.Service;
 
@@ -31,7 +28,6 @@ public class PresignedUrlGenerator implements CreatePresignedUrlPort {
     private final AmazonS3 amazonS3;
     private final FileNameGenerator fileNameGenerator;
     private final ReviewStorageProperties reviewStorageProperties;
-    private final StadiumStorageProperties stadiumStorageProperties;
 
     private static final long EXPIRE_MS = 1000 * 60 * 5L;
 
@@ -55,29 +51,6 @@ public class PresignedUrlGenerator implements CreatePresignedUrlPort {
         }
 
         if (!ImageExtension.isValid(fileExtension)) {
-            throw new InvalidExtensionException(fileExtension);
-        }
-    }
-
-    @Override
-    public String forStadiumSeat(PresignedUrlRequest request) {
-        isValidStadiumMedia(request.getProperty(), request.getFileExtension());
-
-        final StadiumSeatMediaExtension fileExtension =
-                StadiumSeatMediaExtension.from(request.getFileExtension());
-        final String folderName = stadiumStorageProperties.folderName();
-        final String fileName = fileNameGenerator.createStadiumFileName(fileExtension, folderName);
-        final URL url = createPresignedUrl(stadiumStorageProperties.bucketName(), fileName);
-
-        return url.toString();
-    }
-
-    private void isValidStadiumMedia(final MediaProperty property, final String fileExtension) {
-        if (property != MediaProperty.STADIUM) {
-            throw new InvalidStadiumMediaException();
-        }
-
-        if (!StadiumSeatMediaExtension.isValid(fileExtension)) {
             throw new InvalidExtensionException(fileExtension);
         }
     }

--- a/infrastructure/ncp/src/main/java/org/depromeet/spot/ncp/property/ObjectStorageProperties.java
+++ b/infrastructure/ncp/src/main/java/org/depromeet/spot/ncp/property/ObjectStorageProperties.java
@@ -4,5 +4,4 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 // FIXME: ncp 세팅 완료 후, applicaiton.yml 참고해서 prefix 추가
 @ConfigurationProperties(prefix = "ncp.object-storage")
-public record ObjectStorageProperties(
-        String accessKey, String secretKey, String region, String endPoint) {}
+public record ObjectStorageProperties(String accessKey, String secretKey, String bucketName) {}

--- a/infrastructure/ncp/src/main/java/org/depromeet/spot/ncp/property/ObjectStorageProperties.java
+++ b/infrastructure/ncp/src/main/java/org/depromeet/spot/ncp/property/ObjectStorageProperties.java
@@ -2,6 +2,5 @@ package org.depromeet.spot.ncp.property;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-// FIXME: ncp 세팅 완료 후, applicaiton.yml 참고해서 prefix 추가
 @ConfigurationProperties(prefix = "ncp.object-storage")
-public record ObjectStorageProperties(String accessKey, String secretKey, String bucketName) {}
+public record ObjectStorageProperties(String accessKey, String secretKey) {}

--- a/infrastructure/ncp/src/main/java/org/depromeet/spot/ncp/property/ReviewStorageProperties.java
+++ b/infrastructure/ncp/src/main/java/org/depromeet/spot/ncp/property/ReviewStorageProperties.java
@@ -1,7 +1,0 @@
-package org.depromeet.spot.ncp.property;
-
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
-// FIXME: ncp 세팅 완료 후, applicaiton.yml 참고해서 prefix 추가
-@ConfigurationProperties(prefix = "ncp.review-storage")
-public record ReviewStorageProperties(String bucketName, String folderName) {}

--- a/infrastructure/ncp/src/main/java/org/depromeet/spot/ncp/property/StadiumStorageProperties.java
+++ b/infrastructure/ncp/src/main/java/org/depromeet/spot/ncp/property/StadiumStorageProperties.java
@@ -1,7 +1,0 @@
-package org.depromeet.spot.ncp.property;
-
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
-// FIXME: ncp 세팅 완료 후, applicaiton.yml 참고해서 prefix 추가
-@ConfigurationProperties(prefix = "ncp.stadium-storage")
-public record StadiumStorageProperties(String bucketName, String folderName) {}

--- a/infrastructure/ncp/src/main/java/org/depromeet/spot/ncp/resources/application.yaml
+++ b/infrastructure/ncp/src/main/java/org/depromeet/spot/ncp/resources/application.yaml
@@ -2,6 +2,7 @@ ncp:
     object-storage:
         accessKey: ${NCP_OBJECT_STORAGE_ACCESS_KEY}
         secretKey: ${NCP_OBJECT_STORAGE_SECRET_KEY}
+        bucketName: "spot-image-bucket"
     review-storage:
         bucketName: "spot-image-bucket"
         folderName: "review-images"

--- a/infrastructure/ncp/src/main/java/org/depromeet/spot/ncp/resources/application.yaml
+++ b/infrastructure/ncp/src/main/java/org/depromeet/spot/ncp/resources/application.yaml
@@ -2,10 +2,3 @@ ncp:
     object-storage:
         accessKey: ${NCP_OBJECT_STORAGE_ACCESS_KEY}
         secretKey: ${NCP_OBJECT_STORAGE_SECRET_KEY}
-        bucketName: "spot-image-bucket"
-    review-storage:
-        bucketName: "spot-image-bucket"
-        folderName: "review-images"
-    stadium-storage:
-        bucketName: "spot-image-bucket"
-        folderName: "stadium-images"

--- a/infrastructure/ncp/src/test/java/org/depromeet/spot/ncp/objectstorage/PresignedUrlGeneratorTest.java
+++ b/infrastructure/ncp/src/test/java/org/depromeet/spot/ncp/objectstorage/PresignedUrlGeneratorTest.java
@@ -19,7 +19,7 @@ class PresignedUrlGeneratorTest {
     @BeforeEach
     void init() {
         ObjectStorageProperties objectStorageProperties =
-                new ObjectStorageProperties("accessKey", "secretKey", "bucketName");
+                new ObjectStorageProperties("accessKey", "secretKey");
         FakeAmazonS3Config amazonS3 = new FakeAmazonS3Config(objectStorageProperties);
 
         FakeTimeUsecase fakeTimeUsecase = new FakeTimeUsecase("2024-07-09 21:00:00");
@@ -30,7 +30,6 @@ class PresignedUrlGeneratorTest {
                 PresignedUrlGenerator.builder()
                         .amazonS3(amazonS3.getAmazonS3())
                         .fileNameGenerator(fileNameGenerator)
-                        .properties(objectStorageProperties)
                         .build();
     }
 

--- a/infrastructure/ncp/src/test/java/org/depromeet/spot/ncp/objectstorage/PresignedUrlGeneratorTest.java
+++ b/infrastructure/ncp/src/test/java/org/depromeet/spot/ncp/objectstorage/PresignedUrlGeneratorTest.java
@@ -4,13 +4,11 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import org.depromeet.spot.common.exception.media.MediaException.InvalidExtensionException;
 import org.depromeet.spot.common.exception.media.MediaException.InvalidReviewMediaException;
-import org.depromeet.spot.common.exception.media.MediaException.InvalidStadiumMediaException;
 import org.depromeet.spot.domain.media.MediaProperty;
 import org.depromeet.spot.ncp.mock.FakeAmazonS3Config;
 import org.depromeet.spot.ncp.mock.FakeTimeUsecase;
 import org.depromeet.spot.ncp.property.ObjectStorageProperties;
 import org.depromeet.spot.ncp.property.ReviewStorageProperties;
-import org.depromeet.spot.ncp.property.StadiumStorageProperties;
 import org.depromeet.spot.usecase.port.out.media.CreatePresignedUrlPort.PresignedUrlRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,13 +20,11 @@ class PresignedUrlGeneratorTest {
     @BeforeEach
     void init() {
         ObjectStorageProperties objectStorageProperties =
-                new ObjectStorageProperties("accessKey", "secretKey", "region", "endPoint");
+                new ObjectStorageProperties("accessKey", "secretKey", "bucketName");
         FakeAmazonS3Config amazonS3 = new FakeAmazonS3Config(objectStorageProperties);
 
         ReviewStorageProperties reviewStorageProperties =
                 new ReviewStorageProperties("review", "folder");
-        StadiumStorageProperties stadiumStorageProperties =
-                new StadiumStorageProperties("stadium", "folder");
 
         FakeTimeUsecase fakeTimeUsecase = new FakeTimeUsecase("2024-07-09 21:00:00");
         FileNameGenerator fileNameGenerator =
@@ -39,7 +35,6 @@ class PresignedUrlGeneratorTest {
                         .amazonS3(amazonS3.getAmazonS3())
                         .fileNameGenerator(fileNameGenerator)
                         .reviewStorageProperties(reviewStorageProperties)
-                        .stadiumStorageProperties(stadiumStorageProperties)
                         .build();
     }
 
@@ -64,28 +59,6 @@ class PresignedUrlGeneratorTest {
         // when
         // then
         assertThatThrownBy(() -> presignedUrlGenerator.forReview(userId, request))
-                .isInstanceOf(InvalidExtensionException.class);
-    }
-
-    @Test
-    void 경기장_속성이_아니라면_경기장_미디어를_생성할_수_없다() {
-        // given
-        PresignedUrlRequest request = new PresignedUrlRequest("svg", MediaProperty.REVIEW);
-
-        // when
-        // then
-        assertThatThrownBy(() -> presignedUrlGenerator.forStadiumSeat(request))
-                .isInstanceOf(InvalidStadiumMediaException.class);
-    }
-
-    @Test
-    void 경기장_미디어_확장자가_아니라면_경기장_미디어를_생성할_수_없다() {
-        // given
-        PresignedUrlRequest request = new PresignedUrlRequest("mp4", MediaProperty.STADIUM);
-
-        // when
-        // then
-        assertThatThrownBy(() -> presignedUrlGenerator.forStadiumSeat(request))
                 .isInstanceOf(InvalidExtensionException.class);
     }
 }

--- a/infrastructure/ncp/src/test/java/org/depromeet/spot/ncp/objectstorage/PresignedUrlGeneratorTest.java
+++ b/infrastructure/ncp/src/test/java/org/depromeet/spot/ncp/objectstorage/PresignedUrlGeneratorTest.java
@@ -8,7 +8,6 @@ import org.depromeet.spot.domain.media.MediaProperty;
 import org.depromeet.spot.ncp.mock.FakeAmazonS3Config;
 import org.depromeet.spot.ncp.mock.FakeTimeUsecase;
 import org.depromeet.spot.ncp.property.ObjectStorageProperties;
-import org.depromeet.spot.ncp.property.ReviewStorageProperties;
 import org.depromeet.spot.usecase.port.out.media.CreatePresignedUrlPort.PresignedUrlRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,9 +22,6 @@ class PresignedUrlGeneratorTest {
                 new ObjectStorageProperties("accessKey", "secretKey", "bucketName");
         FakeAmazonS3Config amazonS3 = new FakeAmazonS3Config(objectStorageProperties);
 
-        ReviewStorageProperties reviewStorageProperties =
-                new ReviewStorageProperties("review", "folder");
-
         FakeTimeUsecase fakeTimeUsecase = new FakeTimeUsecase("2024-07-09 21:00:00");
         FileNameGenerator fileNameGenerator =
                 FileNameGenerator.builder().timeUsecase(fakeTimeUsecase).build();
@@ -34,7 +30,7 @@ class PresignedUrlGeneratorTest {
                 PresignedUrlGenerator.builder()
                         .amazonS3(amazonS3.getAmazonS3())
                         .fileNameGenerator(fileNameGenerator)
-                        .reviewStorageProperties(reviewStorageProperties)
+                        .properties(objectStorageProperties)
                         .build();
     }
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/CreateStadiumUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/CreateStadiumUsecase.java
@@ -3,17 +3,13 @@ package org.depromeet.spot.usecase.port.in.stadium;
 import org.depromeet.spot.domain.stadium.Stadium;
 import org.springframework.web.multipart.MultipartFile;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
 
 public interface CreateStadiumUsecase {
 
     Stadium create(CreateStadiumReq request);
 
-    @Getter
     @Builder
-    @AllArgsConstructor
     record CreateStadiumReq(
             String name,
             MultipartFile mainImage,

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/CreateStadiumUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/CreateStadiumUsecase.java
@@ -1,0 +1,23 @@
+package org.depromeet.spot.usecase.port.in.stadium;
+
+import org.depromeet.spot.domain.stadium.Stadium;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public interface CreateStadiumUsecase {
+
+    Stadium create(CreateStadiumReq request);
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    record CreateStadiumReq(
+            String name,
+            MultipartFile mainImage,
+            MultipartFile seatingChartImage,
+            MultipartFile labeledSeatingChartImage,
+            boolean isActive) {}
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/media/CreatePresignedUrlPort.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/media/CreatePresignedUrlPort.java
@@ -10,8 +10,6 @@ public interface CreatePresignedUrlPort {
     // FIXME: 유저 도메인 생성 후 userId -> Member 등으로 교체
     String forReview(Long userId, PresignedUrlRequest request);
 
-    String forStadiumSeat(PresignedUrlRequest request);
-
     @Getter
     @AllArgsConstructor
     class PresignedUrlRequest {

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/media/ImageUploadPort.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/media/ImageUploadPort.java
@@ -1,0 +1,9 @@
+package org.depromeet.spot.usecase.port.out.media;
+
+import org.depromeet.spot.domain.media.MediaProperty;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageUploadPort {
+
+    String upload(String target, MultipartFile file, MediaProperty property);
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/CreateStadiumService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/CreateStadiumService.java
@@ -1,0 +1,21 @@
+package org.depromeet.spot.usecase.service.stadium;
+
+import org.depromeet.spot.domain.stadium.Stadium;
+import org.depromeet.spot.usecase.port.in.stadium.CreateStadiumUsecase;
+import org.depromeet.spot.usecase.port.out.stadium.StadiumRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CreateStadiumService implements CreateStadiumUsecase {
+
+    private final StadiumRepository stadiumRepository;
+
+    @Override
+    public Stadium create(CreateStadiumReq request) {
+
+        return null;
+    }
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/CreateStadiumService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/CreateStadiumService.java
@@ -23,12 +23,10 @@ public class CreateStadiumService implements CreateStadiumUsecase {
                 imageUploadPort.upload(name, request.mainImage(), MediaProperty.STADIUM);
         final String seatChartUrl =
                 imageUploadPort.upload(
-                        name + " 좌석 배치도", request.seatingChartImage(), MediaProperty.STADIUM_SEAT);
+                        name, request.seatingChartImage(), MediaProperty.STADIUM_SEAT);
         final String labelSeatChartUrl =
                 imageUploadPort.upload(
-                        name + " label 좌석 배치도",
-                        request.labeledSeatingChartImage(),
-                        MediaProperty.STADIUM_SEAT_LABEL);
+                        name, request.labeledSeatingChartImage(), MediaProperty.STADIUM_SEAT_LABEL);
         Stadium stadium =
                 Stadium.builder()
                         .name(name)

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/CreateStadiumService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/CreateStadiumService.java
@@ -1,7 +1,9 @@
 package org.depromeet.spot.usecase.service.stadium;
 
+import org.depromeet.spot.domain.media.MediaProperty;
 import org.depromeet.spot.domain.stadium.Stadium;
 import org.depromeet.spot.usecase.port.in.stadium.CreateStadiumUsecase;
+import org.depromeet.spot.usecase.port.out.media.ImageUploadPort;
 import org.depromeet.spot.usecase.port.out.stadium.StadiumRepository;
 import org.springframework.stereotype.Service;
 
@@ -12,10 +14,29 @@ import lombok.RequiredArgsConstructor;
 public class CreateStadiumService implements CreateStadiumUsecase {
 
     private final StadiumRepository stadiumRepository;
+    private final ImageUploadPort imageUploadPort;
 
     @Override
     public Stadium create(CreateStadiumReq request) {
-
-        return null;
+        final String name = request.name();
+        final String mainImageUrl =
+                imageUploadPort.upload(name, request.mainImage(), MediaProperty.STADIUM);
+        final String seatChartUrl =
+                imageUploadPort.upload(
+                        name + " 좌석 배치도", request.seatingChartImage(), MediaProperty.STADIUM_SEAT);
+        final String labelSeatChartUrl =
+                imageUploadPort.upload(
+                        name + " label 좌석 배치도",
+                        request.labeledSeatingChartImage(),
+                        MediaProperty.STADIUM_SEAT_LABEL);
+        Stadium stadium =
+                Stadium.builder()
+                        .name(name)
+                        .mainImage(mainImageUrl)
+                        .seatingChartImage(seatChartUrl)
+                        .labeledSeatingChartImage(labelSeatChartUrl)
+                        .isActive(request.isActive())
+                        .build();
+        return stadiumRepository.save(stadium);
     }
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- (어드민) 경기장 등록 API
- (어드민) 이미지 업로드 컴포넌트
  - 유저 API와 다르게, 어드민 API (경기장, 구역, 블럭 생성 etc)는 1차 MVP 기준 클라이언트가 없어요. 
  - presigned url을 이용할 수 없는 환경이기에, 서버에서 직접 이미지를 업로드하도록 컴포넌트를 만들어주었어요.

<br>

## 🔨 작업 사항 (필수)

- 경기장 등록 API
- object storage 이미지 업로드 컴포넌트

<br>

## 🌱 연관 내용 (선택)

- ㅠㅠ 코드가 산만하네요.. 일정이 빠듯해서 일단 올립니당 차차 추상화 해볼게요!

<br>

## 💻 실행 화면 (필수)

- API 성공
<img width="765" alt="스크린샷 2024-07-17 오전 3 29 23" src="https://github.com/user-attachments/assets/5a7f59e3-dfbb-4665-b7af-0395ee17eee8">

- object storage에 파일 업로드 확인
<img width="888" alt="스크린샷 2024-07-17 오전 3 28 06" src="https://github.com/user-attachments/assets/de935fbe-5c51-4db9-8595-bc0b6f41d614">

