### PR TITLE
[BSVR]-119 내 시야기록 조회 API 구현

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/review/ReviewReadController.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/ReviewReadController.java
@@ -1,10 +1,10 @@
 package org.depromeet.spot.application.review;
 
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
 
+import org.depromeet.spot.application.review.dto.request.BlockReviewRequest;
+import org.depromeet.spot.application.review.dto.request.MyReviewRequest;
 import org.depromeet.spot.application.review.dto.response.ReviewListResponse;
 import org.depromeet.spot.domain.review.ReviewListResult;
 import org.depromeet.spot.usecase.port.in.review.ReviewReadUsecase;
@@ -38,21 +38,31 @@ public class ReviewReadController {
                     @Positive
                     @Parameter(description = "블록 PK", required = true)
                     Long blockId,
-            @RequestParam(required = false) @Parameter(description = "열 ID (필터링)") Long rowId,
-            @RequestParam(required = false) @Parameter(description = "좌석 번호 (필터링)") Long seatNumber,
-            @RequestParam(defaultValue = "0")
-                    @PositiveOrZero
-                    @Parameter(description = "시작 위치 (기본값: 0)")
-                    int offset,
-            @RequestParam(defaultValue = "10")
-                    @Positive
-                    @Max(50)
-                    @Parameter(description = "조회할 리뷰 수 (기본값: 10, 최대: 50)")
-                    int limit) {
-
+            @ModelAttribute BlockReviewRequest request) {
         ReviewListResult result =
                 reviewReadUsecase.findReviewsByBlockId(
-                        stadiumId, blockId, rowId, seatNumber, offset, limit);
+                        stadiumId,
+                        blockId,
+                        request.rowId(),
+                        request.seatNumber(),
+                        request.offset(),
+                        request.limit());
+        return ReviewListResponse.from(result);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/reviews")
+    @Operation(
+            summary = " 자신이 작성한 리뷰 목록을 조회한다.",
+            description = "연도와 월로 필터링할 수 있다. 필터링 없이 전체를 조회하려면 year와 month를 null로 입력한다.")
+    public ReviewListResponse findMyReviews(@ModelAttribute MyReviewRequest request) {
+        ReviewListResult result =
+                reviewReadUsecase.findMyReviews(
+                        request.userId(),
+                        request.offset(),
+                        request.limit(),
+                        request.year(),
+                        request.month());
         return ReviewListResponse.from(result);
     }
 }

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/request/BlockReviewRequest.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/request/BlockReviewRequest.java
@@ -1,12 +1,13 @@
 package org.depromeet.spot.application.review.dto.request;
 
 import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 
 import io.swagger.v3.oas.annotations.Parameter;
 
-public record ReviewBlockRequest(
+public record BlockReviewRequest(
         @Parameter(description = "열 ID (필터링)") Long rowId,
         @Parameter(description = "좌석 번호 (필터링)") Long seatNumber,
         @PositiveOrZero @Parameter(description = "시작 위치 (기본값: 0)") int offset,
-        @Max(50) @Parameter(description = "조회할 리뷰 수 (기본값: 10, 최대: 50)") int limit) {}
+        @Positive @Max(50) @Parameter(description = "조회할 리뷰 수 (기본값: 10, 최대: 50)") int limit) {}

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/request/MyReviewRequest.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/request/MyReviewRequest.java
@@ -1,0 +1,14 @@
+package org.depromeet.spot.application.review.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.PositiveOrZero;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+public record MyReviewRequest(
+        @Parameter(description = "유저 ID") Long userId,
+        @PositiveOrZero @Parameter(description = "시작 위치 (기본값: 0)") Integer offset,
+        @Min(1) @Max(50) @Parameter(description = "조회할 리뷰 수 (기본값: 10, 최대: 50)") Integer limit,
+        @Min(1000) @Max(9999) @Parameter(description = "년도 (4자리 숫자)") Integer year,
+        @Min(1) @Max(12) @Parameter(description = "월 (1-12)") Integer month) {}

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewCustomRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewCustomRepository.java
@@ -47,10 +47,6 @@ public class ReviewCustomRepository {
 
     public List<ReviewEntity> findByUserIdWithFilters(
             Long userId, int offset, int limit, Integer year, Integer month) {
-        System.out.printf(
-                "userId: %d, offset: %d, limit: %d, year: %d, month: %d\n",
-                userId, offset, limit, year, month);
-
         return queryFactory
                 .selectFrom(reviewEntity)
                 .where(

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewCustomRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewCustomRepository.java
@@ -45,6 +45,30 @@ public class ReviewCustomRepository {
                 .fetch();
     }
 
+    public List<ReviewEntity> findByUserIdWithFilters(
+            Long userId, int offset, int limit, Integer year, Integer month) {
+        System.out.printf(
+                "userId: %d, offset: %d, limit: %d, year: %d, month: %d\n",
+                userId, offset, limit, year, month);
+
+        return queryFactory
+                .selectFrom(reviewEntity)
+                .where(
+                        reviewEntity
+                                .userId
+                                .eq(userId)
+                                .and(year != null ? reviewEntity.createdAt.year().eq(year) : null)
+                                .and(
+                                        month != null
+                                                ? reviewEntity.createdAt.month().eq(month)
+                                                : null)
+                                .and(reviewEntity.deletedAt.isNull()))
+                .orderBy(reviewEntity.createdAt.desc())
+                .offset(offset)
+                .limit(limit)
+                .fetch();
+    }
+
     public long countByBlockIdWithFilters(
             Long stadiumId, Long blockId, Long rowId, Long seatNumber) {
         return queryFactory
@@ -60,7 +84,25 @@ public class ReviewCustomRepository {
                                                 ? reviewEntity.seatNumber.eq(seatNumber)
                                                 : null)
                                 .and(reviewEntity.deletedAt.isNull()))
-                .fetchCount();
+                .stream()
+                .count();
+    }
+
+    public long countByUserIdWithFilters(Long userId, Integer year, Integer month) {
+        return queryFactory
+                .selectFrom(reviewEntity)
+                .where(
+                        reviewEntity
+                                .userId
+                                .eq(userId)
+                                .and(year != null ? reviewEntity.createdAt.year().eq(year) : null)
+                                .and(
+                                        month != null
+                                                ? reviewEntity.createdAt.month().eq(month)
+                                                : null)
+                                .and(reviewEntity.deletedAt.isNull()))
+                .stream()
+                .count();
     }
 
     public List<KeywordCount> findTopKeywordsByBlockId(Long stadiumId, Long blockId, int limit) {

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewRepositoryImpl.java
@@ -28,9 +28,22 @@ public class ReviewRepositoryImpl implements ReviewRepository {
     }
 
     @Override
+    public List<Review> findByUserId(
+            Long userId, int offset, int limit, Integer year, Integer month) {
+        List<ReviewEntity> reviews =
+                reviewCustomRepository.findByUserIdWithFilters(userId, offset, limit, year, month);
+        return reviews.stream().map(this::fetchReviewDetails).collect(Collectors.toList());
+    }
+
+    @Override
     public Long countByBlockId(Long stadiumId, Long blockId, Long rowId, Long seatNumber) {
         return reviewCustomRepository.countByBlockIdWithFilters(
                 stadiumId, blockId, rowId, seatNumber);
+    }
+
+    @Override
+    public Long countByUserId(Long userId, Integer year, Integer month) {
+        return reviewCustomRepository.countByUserIdWithFilters(userId, year, month);
     }
 
     @Override

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReviewReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReviewReadUsecase.java
@@ -5,4 +5,6 @@ import org.depromeet.spot.domain.review.ReviewListResult;
 public interface ReviewReadUsecase {
     ReviewListResult findReviewsByBlockId(
             Long stadiumId, Long blockId, Long rowId, Long seatNumber, int offset, int limit);
+
+    ReviewListResult findMyReviews(Long userId, int offset, int limit, Integer year, Integer month);
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewRepository.java
@@ -9,7 +9,11 @@ public interface ReviewRepository {
     List<Review> findByBlockId(
             Long stadiumId, Long blockId, Long rowId, Long seatNumber, int offset, int limit);
 
+    List<Review> findByUserId(Long userId, int offset, int limit, Integer year, Integer month);
+
     Long countByBlockId(Long stadiumId, Long blockId, Long rowId, Long seatNumber);
+
+    Long countByUserId(Long userId, Integer year, Integer month);
 
     List<KeywordCount> findTopKeywordsByBlockId(Long stadiumId, Long blockId, int limit);
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReviewReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReviewReadService.java
@@ -1,5 +1,6 @@
 package org.depromeet.spot.usecase.service.review;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.depromeet.spot.domain.review.KeywordCount;
@@ -27,6 +28,16 @@ public class ReviewReadService implements ReviewReadUsecase {
         Long totalCount = reviewRepository.countByBlockId(stadiumId, blockId, rowId, seatNumber);
         List<KeywordCount> topKeywords =
                 reviewRepository.findTopKeywordsByBlockId(stadiumId, blockId, TOP_KEYWORDS_LIMIT);
+
+        return new ReviewListResult(reviews, topKeywords, totalCount, offset, limit);
+    }
+
+    @Override
+    public ReviewListResult findMyReviews(
+            Long userId, int offset, int limit, Integer year, Integer month) {
+        List<Review> reviews = reviewRepository.findByUserId(userId, offset, limit, year, month);
+        Long totalCount = reviewRepository.countByUserId(userId, year, month);
+        List<KeywordCount> topKeywords = Collections.emptyList(); // 사용자 리뷰에 대한 탑 키워드 모음 필요 없음
 
         return new ReviewListResult(reviews, topKeywords, totalCount, offset, limit);
     }

--- a/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeReviewRepository.java
+++ b/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeReviewRepository.java
@@ -76,6 +76,27 @@ public class FakeReviewRepository implements ReviewRepository {
                 .collect(Collectors.toList());
     }
 
+    @Override
+    public List<Review> findByUserId(
+            Long userId, int offset, int limit, Integer year, Integer month) {
+        return data.stream()
+                .filter(review -> review.getUserId().equals(userId))
+                .filter(review -> year == null || review.getCreatedAt().getYear() == year)
+                .filter(review -> month == null || review.getCreatedAt().getMonthValue() == month)
+                .skip(offset)
+                .limit(limit)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Long countByUserId(Long userId, Integer year, Integer month) {
+        return data.stream()
+                .filter(review -> review.getUserId().equals(userId))
+                .filter(review -> year == null || review.getCreatedAt().getYear() == year)
+                .filter(review -> month == null || review.getCreatedAt().getMonthValue() == month)
+                .count();
+    }
+
     public void save(Review review) {
         data.add(review);
     }

--- a/usecase/src/test/java/org/depromeet/spot/usecase/service/review/ReviewReadServiceTest.java
+++ b/usecase/src/test/java/org/depromeet/spot/usecase/service/review/ReviewReadServiceTest.java
@@ -115,4 +115,35 @@ class ReviewReadServiceTest {
         assertEquals(10, result.reviews().size());
         assertEquals(20, result.totalCount());
     }
+
+    @Test
+    void findMyReviews는_유저별_리뷰를_정상적으로_반환한다() {
+        // Given
+        Review review1 =
+                Review.builder()
+                        .id(1L)
+                        .userId(1L)
+                        .content("Great game!")
+                        .keywords(Collections.singletonList(createReviewKeyword(1L, 1L, 1L, true)))
+                        .build();
+        Review review2 =
+                Review.builder()
+                        .id(2L)
+                        .userId(1L)
+                        .content("Amazing view!")
+                        .keywords(
+                                Collections.singletonList(
+                                        createReviewKeyword(2L, 2L, 2L, true))) // 다른 keywordId 사용
+                        .build();
+        fakeReviewRepository.save(review1);
+        fakeReviewRepository.save(review2);
+
+        // When
+        ReviewListResult result = reviewReadService.findMyReviews(1L, 0, 10, null, null);
+
+        // Then
+        assertEquals(2, result.reviews().size());
+        assertEquals(2, result.totalCount());
+        assertEquals(0, result.topKeywords().size());
+    }
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- 내 시야기록 조회 API 구현했어요.

<br>

## 🔨 작업 사항 (필수)

- 필터링 가능한 레포지토리 및 서비스 함수 구현
- request dto와 controller 구현

<br>

## ⚡️ 관심 리뷰 (선택)

- 아래 코멘트에서 확인해주세요.

<br>

## 🌱 연관 내용 (선택)

- 준원이 PR이 머지되서 이제 유저 정보가 토큰 형태로 들어오면 userId 추출하는 리팩토링 필요!

<br>

## 💻 실행 화면 (필수)

- 필터링 없이 전체 조회

![image](https://github.com/user-attachments/assets/40440936-cdec-4d5d-8467-04a2da775b41)

- 연도 필터링 조회

![image](https://github.com/user-attachments/assets/e3eec103-f14b-4ba6-ba29-d8c43fca543d)

- 아이템 없는 경우 -> 200 ok 지만 reviews 배열이 비어있는 형태로 반환

![image](https://github.com/user-attachments/assets/b38c162d-9d54-4832-b5c0-31463ec0dfbd)

- 테스트 결과

![image](https://github.com/user-attachments/assets/d4fdc259-f69a-4c55-9b5c-aaa0745a07b8)

