### PR TITLE
[BSVR-130] 경기장 조회 API res에 썸네일 추가

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumInfoWithSeatChartResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumInfoWithSeatChartResponse.java
@@ -8,7 +8,11 @@ import lombok.Builder;
 
 @Builder
 public record StadiumInfoWithSeatChartResponse(
-        Long id, String name, String seatChartWithLabel, List<HomeTeamInfoResponse> homeTeams) {
+        Long id,
+        String name,
+        String seatChartWithLabel,
+        String thumbnail,
+        List<HomeTeamInfoResponse> homeTeams) {
 
     public static StadiumInfoWithSeatChartResponse from(
             StadiumInfoWithSeatChart stadiumInfoWithSeatChart) {
@@ -21,6 +25,7 @@ public record StadiumInfoWithSeatChartResponse(
                 stadiumInfoWithSeatChart.getId(),
                 stadiumInfoWithSeatChart.getName(),
                 stadiumInfoWithSeatChart.getSeatChartWithLabel(),
+                stadiumInfoWithSeatChart.getThumbnail(),
                 homeTeams);
     }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/StadiumReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/StadiumReadUsecase.java
@@ -41,6 +41,7 @@ public interface StadiumReadUsecase {
         private final String name;
         private final List<HomeTeamInfo> homeTeams;
         private final String seatChartWithLabel;
+        private final String thumbnail;
     }
 
     @Getter

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/StadiumReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/StadiumReadService.java
@@ -2,7 +2,6 @@ package org.depromeet.spot.usecase.service.stadium;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.depromeet.spot.common.exception.stadium.StadiumException.StadiumNotFoundException;
 import org.depromeet.spot.domain.stadium.Stadium;
@@ -41,7 +40,7 @@ public class StadiumReadService implements StadiumReadUsecase {
                                                                     t.getId(),
                                                                     t.getAlias(),
                                                                     t.getLabelRgbCode()))
-                                            .collect(Collectors.toList());
+                                            .toList();
 
                             return new StadiumHomeTeamInfo(
                                     stadium.getId(),
@@ -67,6 +66,7 @@ public class StadiumReadService implements StadiumReadUsecase {
                 .id(stadium.getId())
                 .name(stadium.getName())
                 .homeTeams(homeTeams)
+                .thumbnail(stadium.getMainImage())
                 .seatChartWithLabel(stadium.getLabeledSeatingChartImage())
                 .build();
     }


### PR DESCRIPTION
## 📌 개요 (필수)

- 클라이언트 요청으로 특정 경기장 조회 API에 경기장 메인 이미지 res 추가

<br>

## 🔨 작업 사항 (필수)

- 개요와 동일!

## 💻 실행 화면 (필수)
<img width="921" alt="스크린샷 2024-07-18 오전 1 21 07" src="https://github.com/user-attachments/assets/f8a84aeb-c979-4bd6-8753-1e4c7bba31ef">
