### PR TITLE
[NO_JIRA_KAKAO_oauth] 안드로이드에 맞도록 accessToken을 사용해 회원가입/로그인 처리

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/member/controller/MemberController.java
+++ b/application/src/main/java/org/depromeet/spot/application/member/controller/MemberController.java
@@ -39,20 +39,23 @@ public class MemberController {
     public JwtTokenResponse create(@RequestBody @Valid RegisterReq request) {
 
         Member member = request.toDomain();
-        Member memberResult = memberUsecase.create(member);
+        Member memberResult = memberUsecase.create(request.accessToken(), member);
 
         return new JwtTokenResponse(jwtTokenUtil.getJWTToken(memberResult));
     }
 
-    @GetMapping("/{idCode}")
+    @GetMapping("/{accessToken}")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Member 로그인 API")
     public JwtTokenResponse login(
-            @PathVariable("idCode")
-                    @Parameter(name = "idCode", description = "sns idCode", required = true)
-                    String idCode) {
+            @PathVariable("accessToken")
+                    @Parameter(
+                            name = "accessToken",
+                            description = "sns accessToken",
+                            required = true)
+                    String accessToken) {
 
-        Member member = memberUsecase.login(idCode);
+        Member member = memberUsecase.login(accessToken);
 
         return new JwtTokenResponse(jwtTokenUtil.getJWTToken(member));
     }
@@ -66,5 +69,15 @@ public class MemberController {
                     String nickname) {
         Boolean result = memberUsecase.duplicatedNickname(nickname);
         return result;
+    }
+
+    @GetMapping("/accessToken/{idCode}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "(백엔드용)accessToken을 받아오기 위한 API")
+    public String getAccessToken(
+            @PathVariable("idCode")
+                    @Parameter(name = "idCode", description = "카카오에서 발급 받은 idCode", required = true)
+                    String idCode) {
+        return memberUsecase.getAccessToken(idCode);
     }
 }

--- a/application/src/main/java/org/depromeet/spot/application/member/dto/request/RegisterReq.java
+++ b/application/src/main/java/org/depromeet/spot/application/member/dto/request/RegisterReq.java
@@ -10,8 +10,8 @@ import org.hibernate.validator.constraints.Range;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record RegisterReq(
-        @NotNull(message = "인가 id code는 필수 값입니다.") @Schema(description = "인가 id code")
-                String idCode,
+        @NotNull(message = "인가 accessToken는 필수 값입니다.") @Schema(description = "카카오 인증 accessToken")
+                String accessToken,
         @NotNull(message = "닉네임 값은 필수입니다.")
                 @Schema(description = "설정하려는 닉네임")
                 @Length(min = 2, max = 10, message = "닉네임은 2글자에서 10글자 사이여야합니다.")
@@ -25,6 +25,6 @@ public record RegisterReq(
                 Long teamId) {
 
     public Member toDomain() {
-        return Member.builder().idToken(idCode).nickname(nickname).teamId(teamId).build();
+        return Member.builder().nickname(nickname).teamId(teamId).build();
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/oauth/OauthRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/oauth/OauthRepositoryImpl.java
@@ -80,6 +80,7 @@ public class OauthRepositoryImpl implements OauthRepository {
 
         // TODO : idToken이 변경 될 수 있음. 등록된 email도 변경될 수 있기에 추 후 논의가 필요.
         // 기존 유저와 비교를 위해선 idToken만 필요함.
+        // 앱에서는 accessToken을 반환해주기에 accessToken으로 로직 처리
         return userInfo.toLoginDomain();
     }
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/member/MemberUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/member/MemberUsecase.java
@@ -4,9 +4,11 @@ import org.depromeet.spot.domain.member.Member;
 
 public interface MemberUsecase {
 
-    Member create(Member member);
+    Member create(String accessToken, Member member);
 
     Member login(String idCode);
 
     Boolean duplicatedNickname(String nickname);
+
+    String getAccessToken(String idCode);
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/member/MemberService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/member/MemberService.java
@@ -21,11 +21,10 @@ public class MemberService implements MemberUsecase {
     private final MemberRepository memberRepository;
 
     @Override
-    public Member create(Member member) {
+    public Member create(String accessToken, Member member) {
         if (memberRepository.existsByNickname(member.getNickname())) {
             throw new MemberNicknameConflictException();
         }
-        String accessToken = oauthRepository.getKakaoAccessToken(member.getIdToken());
         Member memberResult = oauthRepository.getRegisterUserInfo(accessToken, member);
         Optional<Member> existedMember = memberRepository.findByIdToken(memberResult.getIdToken());
         if (existedMember.isPresent()) {
@@ -36,8 +35,7 @@ public class MemberService implements MemberUsecase {
     }
 
     @Override
-    public Member login(String idCode) {
-        String accessToken = oauthRepository.getKakaoAccessToken(idCode);
+    public Member login(String accessToken) {
         Member memberResult = oauthRepository.getLoginUserInfo(accessToken);
         Optional<Member> existedMember = memberRepository.findByIdToken(memberResult.getIdToken());
         if (existedMember.isEmpty()) {
@@ -51,5 +49,10 @@ public class MemberService implements MemberUsecase {
         if (memberRepository.existsByNickname(nickname))
             throw new MemberNicknameConflictException();
         return Boolean.FALSE;
+    }
+
+    @Override
+    public String getAccessToken(String idCode) {
+        return oauthRepository.getKakaoAccessToken(idCode);
     }
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- accessToken을 사용한 회원가입/로그인 처리

<br>

## 🔨 작업 사항 (필수)

- 회원가입/로그인 AccessToken을 사용하도록 변경
- 백엔드 테스트를 위해 IdCode를 사용해 AccessToken을 가져오는 API 생성
  - 회원가입/로그인 테스트 시 기존 방식대로 IdCode를 가져와 getAccessToken API로 AccessToken을 가져온 후 회원가입/로그인 파라미터로 넘겨줘야해...!!

<br>

## 💻 실행 화면 (필수)

- 로그인
![image](https://github.com/user-attachments/assets/00078e05-bc7c-4cf0-b94e-6c00ef16b83e)

- 회원가입
![image](https://github.com/user-attachments/assets/4e3a4737-cfb1-4852-8152-77652e1c0a03)

- AccessToken 가져오기
![image](https://github.com/user-attachments/assets/2018d391-5124-4653-8234-eba7814351c5)

