### PR TITLE
[NO_JIRA_KAKAO_oauth] 로그인 시 존재하지 않는 유저는 빈 JWT 리턴하도록 변경

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/member/controller/MemberController.java
+++ b/application/src/main/java/org/depromeet/spot/application/member/controller/MemberController.java
@@ -56,7 +56,9 @@ public class MemberController {
                     String accessToken) {
 
         Member member = memberUsecase.login(accessToken);
-
+        if (member == null) {
+            return new JwtTokenResponse("");
+        }
         return new JwtTokenResponse(jwtTokenUtil.getJWTToken(member));
     }
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/member/MemberService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/member/MemberService.java
@@ -3,7 +3,6 @@ package org.depromeet.spot.usecase.service.member;
 import java.util.Optional;
 
 import org.depromeet.spot.common.exception.member.MemberException.MemberNicknameConflictException;
-import org.depromeet.spot.common.exception.member.MemberException.MemberNotFoundException;
 import org.depromeet.spot.domain.member.Member;
 import org.depromeet.spot.usecase.port.in.member.MemberUsecase;
 import org.depromeet.spot.usecase.port.out.member.MemberRepository;
@@ -39,7 +38,9 @@ public class MemberService implements MemberUsecase {
         Member memberResult = oauthRepository.getLoginUserInfo(accessToken);
         Optional<Member> existedMember = memberRepository.findByIdToken(memberResult.getIdToken());
         if (existedMember.isEmpty()) {
-            throw new MemberNotFoundException();
+            // TODO : 404 말고 사용되지 않는 Exception 코드가 필요함.
+            //            throw new MemberNotFoundException();
+            return null;
         }
         return existedMember.get();
     }


### PR DESCRIPTION
## 📌 개요 (필수)

- 로그인 시 존재하지 않는 유저 빈 JWT 리턴하도록 변경

<br>

## 🔨 작업 사항 (필수)

- 카카오 로그인/회원가입 화면 통일.
  - 로그인 요청 후 존재하지 않을 경우 빈 JWT 리턴.
  - 회원가입 flow로 이동하도록 함

<br>

## 💻 실행 화면 (필수)

- 로그인
![image](https://github.com/user-attachments/assets/65e774ee-f232-4108-b469-1e1eb2eee969)

- 로그인 실패
![image](https://github.com/user-attachments/assets/a0b9e4f9-4b57-4a5f-b910-8ee98b9889d9)
