### PR TITLE
[BSVR-142] 구역 내 블록 조회시 블럭 코드 오름차순 정렬

### DIFF
--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/block/repository/BlockJpaRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/block/repository/BlockJpaRepository.java
@@ -5,11 +5,14 @@ import java.util.Optional;
 
 import org.depromeet.spot.jpa.block.entity.BlockEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BlockJpaRepository extends JpaRepository<BlockEntity, Long> {
     Optional<BlockEntity> findByStadiumIdAndCode(Long stadiumId, String code);
 
-    List<BlockEntity> findAllBySectionId(Long sectionId);
+    @Query("SELECT b FROM BlockEntity b where b.sectionId = :sectionId order by b.code asc")
+    List<BlockEntity> findAllBySectionId(@Param("sectionId") Long sectionId);
 
     boolean existsByStadiumIdAndCode(Long stadiumId, String code);
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- 특정 경기장 특정 구역 내에 있는 블럭 리스트를 조회할 때, 블럭 코드 오름차순이 되게 정렬을 추가해요

<br>

## 🔨 작업 사항 (필수)

- 개요와 동일

<br>

## 💻 실행 화면 (필수)

<img width="185" alt="스크린샷 2024-07-21 오후 1 39 25" src="https://github.com/user-attachments/assets/0f4c0b18-5c2d-4d60-b6a4-c86860901e1e">
