### PR TITLE
[NO_JIRA] accessToken을 사용한 멤버 삭제 API

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/member/controller/MemberController.java
+++ b/application/src/main/java/org/depromeet/spot/application/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import org.depromeet.spot.application.member.dto.response.JwtTokenResponse;
 import org.depromeet.spot.domain.member.Member;
 import org.depromeet.spot.usecase.port.in.member.MemberUsecase;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -81,5 +82,19 @@ public class MemberController {
                     @Parameter(name = "idCode", description = "카카오에서 발급 받은 idCode", required = true)
                     String idCode) {
         return memberUsecase.getAccessToken(idCode);
+    }
+
+    @DeleteMapping("/{accessToken}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "(개발용) Member 삭제 API")
+    public Boolean deleteMember(
+            @PathVariable("accessToken")
+                    @Parameter(
+                            name = "accessToken",
+                            description = "sns accessToken",
+                            required = true)
+                    String accessToken) {
+        // TODO : (개발용) 유저 탈퇴 아님! 단순 유저 삭제만 진행함.
+        return memberUsecase.deleteMember(accessToken);
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberJpaRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberJpaRepository.java
@@ -25,4 +25,6 @@ public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
             @Param("profileImage") String profileImage,
             @Param("teamId") Long teamId,
             @Param("nickname") String nickname);
+
+    void deleteByIdToken(String idToken);
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberRepositoryImpl.java
@@ -45,4 +45,9 @@ public class MemberRepositoryImpl implements MemberRepository {
                 memberJpaRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
         return entity.toDomain();
     }
+
+    @Override
+    public void deleteByIdToken(String idToken) {
+        memberJpaRepository.deleteByIdToken(idToken);
+    }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/member/MemberUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/member/MemberUsecase.java
@@ -11,4 +11,6 @@ public interface MemberUsecase {
     Boolean duplicatedNickname(String nickname);
 
     String getAccessToken(String idCode);
+
+    Boolean deleteMember(String accessToken);
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/member/MemberRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/member/MemberRepository.java
@@ -15,4 +15,6 @@ public interface MemberRepository {
     Boolean existsByNickname(String nickname);
 
     Member findById(Long memberId);
+
+    void deleteByIdToken(String idToken);
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- accessToken을 사용한 멤버 삭제 구현

<br>

## 🔨 작업 사항 (필수)

- 멤버 삭제 API
 - TODO : 회원 탈퇴가 아니므로 추후 개발해야함.

<br>

## 💻 실행 화면 (필수)

- 멤버 삭제 성공
![image](https://github.com/user-attachments/assets/d8505424-49a1-4a1e-abcd-c37ff74b01bf)

- 멤버 삭제 실패
![image](https://github.com/user-attachments/assets/6bd071bf-fb0a-4f8d-a18c-c482ebb2906b)
