### PR TITLE
[BSVR-78] Jwt 토큰 수정, 헤더 jwt 토큰에서 memberId 가져오는 AOP 추가

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -23,6 +23,9 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
     implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
+    // aop
+    implementation("org.springframework.boot:spring-boot-starter-aop")
+
 }
 
 // spring boot main application이므로 실행 가능한 jar를 생성한다.

--- a/application/src/main/java/org/depromeet/spot/application/common/annotation/CurrentMember.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/annotation/CurrentMember.java
@@ -15,4 +15,4 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.METHOD) // 적용 대상 : 메소드
 @Retention(RetentionPolicy.RUNTIME) // 런타임에 사용할 수 있도록 설정
-public @interface MemberId {}
+public @interface CurrentMember {}

--- a/application/src/main/java/org/depromeet/spot/application/common/annotation/MemberId.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/annotation/MemberId.java
@@ -1,0 +1,18 @@
+package org.depromeet.spot.application.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 해당 어노테이션은 헤더에 담긴 Jwt 토큰에서 <b>memberId</b> 값을 가져오는 어노테이션입니다. <br>
+ * 컨트롤러에서 사용하려는 <b>메소드</b>에 사용하면됩니다. <br>
+ * <br>
+ * <b>파라미터</b>에 <b>Long memberId</b>를 추가해주어야 합니다. <br>
+ * <b>@Parameter(hidden = true) Long memberId</b>로 하시면 <br>
+ * 해당 파라미터는 Swagger에서 제외됩니다. :)
+ */
+@Target(ElementType.METHOD) // 적용 대상 : 메소드
+@Retention(RetentionPolicy.RUNTIME) // 런타임에 사용할 수 있도록 설정
+public @interface MemberId {}

--- a/application/src/main/java/org/depromeet/spot/application/common/aop/JwtTokenAspect.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/aop/JwtTokenAspect.java
@@ -24,27 +24,21 @@ public class JwtTokenAspect {
 
     @Around("@annotation(org.depromeet.spot.application.common.annotation.MemberId)")
     public Object getMemberIdFromTokenAspect(ProceedingJoinPoint joinPoint) throws Throwable {
-        String jwtToken = request.getHeader("Authorization");
-        String access_token = jwtToken.split(" ")[1];
+        Long memberId = jwtTokenUtil.getIdFromJWT(jwtTokenUtil.getAccessToken(request));
 
-        Long memberId = jwtTokenUtil.getIdFromJWT(access_token);
-        if (memberId != null) {
-            // 동작하는 메소드의 시그니처를 가져옴.
-            MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-            Object[] args = joinPoint.getArgs();
-            Class<?>[] parameterTypes = signature.getParameterTypes();
-            String[] parameterNames = signature.getParameterNames();
+        // 동작하는 메소드의 시그니처를 가져옴.
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Object[] args = joinPoint.getArgs();
+        Class<?>[] parameterTypes = signature.getParameterTypes();
+        String[] parameterNames = signature.getParameterNames();
 
-            for (int i = 0; i < args.length; i++) {
-                if ("memberId".equals(parameterNames[i]) && parameterTypes[i] == Long.class) {
-                    args[i] = memberId; // memberId로 변경
-                }
+        for (int i = 0; i < args.length; i++) {
+            if ("memberId".equals(parameterNames[i]) && parameterTypes[i] == Long.class) {
+                args[i] = memberId; // memberId로 변경
             }
-
-            // 변경된 인자로 메서드 실행
-            return joinPoint.proceed(args);
         }
 
-        throw new RuntimeException("토큰 내에 memberId가 없습니다.");
+        // 변경된 인자로 메서드 실행
+        return joinPoint.proceed(args);
     }
 }

--- a/application/src/main/java/org/depromeet/spot/application/common/aop/JwtTokenAspect.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/aop/JwtTokenAspect.java
@@ -22,14 +22,6 @@ public class JwtTokenAspect {
 
     private final HttpServletRequest request;
 
-    // Before 사용 시
-    // [ProjectingArgumentResolverRegistrar.class]: BeanPostProcessor before instantiation of bean
-    // failed
-    // 에러 발생함. 이유 아직 모르겠음 ㅠㅠ
-    //
-    // Q) Around는  ProceedingJoinPoint를 사용하여 메소드를 호출할 수 있고,
-    // 메서드의 인자를 변경하거나 직접적으로 메소드의 실행을 제어가능함.
-    // Before는 실행 전에만 동작하면서 메소드의 인자를 바꾸거나 직접 제어가 불가능함.
     @Around("@annotation(org.depromeet.spot.application.common.annotation.MemberId)")
     public Object getMemberIdFromTokenAspect(ProceedingJoinPoint joinPoint) throws Throwable {
         String jwtToken = request.getHeader("Authorization");

--- a/application/src/main/java/org/depromeet/spot/application/common/aop/JwtTokenAspect.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/aop/JwtTokenAspect.java
@@ -34,9 +34,8 @@ public class JwtTokenAspect {
     public Object getMemberIdFromTokenAspect(ProceedingJoinPoint joinPoint) throws Throwable {
         String jwtToken = request.getHeader("Authorization");
         String access_token = jwtToken.split(" ")[1];
-        log.info("jwtToken : {}", access_token);
-        log.info("memberId : {}", jwtTokenUtil.getIdFromJWT(access_token));
-        Long memberId = Long.valueOf(jwtTokenUtil.getIdFromJWT(access_token));
+
+        Long memberId = jwtTokenUtil.getIdFromJWT(access_token);
         if (memberId != null) {
             // 동작하는 메소드의 시그니처를 가져옴.
             MethodSignature signature = (MethodSignature) joinPoint.getSignature();

--- a/application/src/main/java/org/depromeet/spot/application/common/aop/JwtTokenAspect.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/aop/JwtTokenAspect.java
@@ -1,0 +1,59 @@
+package org.depromeet.spot.application.common.aop;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.depromeet.spot.application.common.jwt.JwtTokenUtil;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Aspect
+@RequiredArgsConstructor
+@Slf4j
+public class JwtTokenAspect {
+
+    private final JwtTokenUtil jwtTokenUtil;
+
+    private final HttpServletRequest request;
+
+    // Before 사용 시
+    // [ProjectingArgumentResolverRegistrar.class]: BeanPostProcessor before instantiation of bean
+    // failed
+    // 에러 발생함. 이유 아직 모르겠음 ㅠㅠ
+    //
+    // Q) Around는  ProceedingJoinPoint를 사용하여 메소드를 호출할 수 있고,
+    // 메서드의 인자를 변경하거나 직접적으로 메소드의 실행을 제어가능함.
+    // Before는 실행 전에만 동작하면서 메소드의 인자를 바꾸거나 직접 제어가 불가능함.
+    @Around("@annotation(org.depromeet.spot.application.common.annotation.MemberId)")
+    public Object getMemberIdFromTokenAspect(ProceedingJoinPoint joinPoint) throws Throwable {
+        String jwtToken = request.getHeader("Authorization");
+        String access_token = jwtToken.split(" ")[1];
+        log.info("jwtToken : {}", access_token);
+        log.info("memberId : {}", jwtTokenUtil.getIdFromJWT(access_token));
+        Long memberId = Long.valueOf(jwtTokenUtil.getIdFromJWT(access_token));
+        if (memberId != null) {
+            // 동작하는 메소드의 시그니처를 가져옴.
+            MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+            Object[] args = joinPoint.getArgs();
+            Class<?>[] parameterTypes = signature.getParameterTypes();
+            String[] parameterNames = signature.getParameterNames();
+
+            for (int i = 0; i < args.length; i++) {
+                if ("memberId".equals(parameterNames[i]) && parameterTypes[i] == Long.class) {
+                    args[i] = memberId; // memberId로 변경
+                }
+            }
+
+            // 변경된 인자로 메서드 실행
+            return joinPoint.proceed(args);
+        }
+
+        throw new RuntimeException("토큰 내에 memberId가 없습니다.");
+    }
+}

--- a/application/src/main/java/org/depromeet/spot/application/common/aop/JwtTokenAspect.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/aop/JwtTokenAspect.java
@@ -22,7 +22,7 @@ public class JwtTokenAspect {
 
     private final HttpServletRequest request;
 
-    @Around("@annotation(org.depromeet.spot.application.common.annotation.MemberId)")
+    @Around("@annotation(org.depromeet.spot.application.common.annotation.CurrentMember)")
     public Object getMemberIdFromTokenAspect(ProceedingJoinPoint joinPoint) throws Throwable {
         Long memberId = jwtTokenUtil.getIdFromJWT(jwtTokenUtil.getAccessToken(request));
 

--- a/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtAuthenticationFilter.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtAuthenticationFilter.java
@@ -54,11 +54,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (header.startsWith("Bearer")) {
                 String access_token = header.split(" ")[1];
                 if (jwtTokenUtil.isValidateToken(access_token)) {
-                    String memberId = jwtTokenUtil.getIdFromJWT(access_token);
+                    Long memberId = jwtTokenUtil.getIdFromJWT(access_token);
                     MemberRole role = MemberRole.valueOf(jwtTokenUtil.getRoleFromJWT(access_token));
                     JwtToken jwtToken = new JwtToken(memberId, role);
                     SecurityContextHolder.getContext().setAuthentication(jwtToken);
                     filterChain.doFilter(request, response);
+                    return;
                 }
             }
             // 토큰 검증 실패 -> Exception

--- a/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtAuthenticationFilter.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtAuthenticationFilter.java
@@ -51,7 +51,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // header가 null이거나 빈 문자열이면 안됨.
         if (header != null && !header.equalsIgnoreCase("")) {
-            if (header.startsWith("Bearer")) {
+            if (header.startsWith(JwtTokenEnums.BEARER.getValue())) {
                 String accessToken = header.split(" ")[1];
                 if (jwtTokenUtil.isValidateToken(accessToken)) {
                     Long memberId = jwtTokenUtil.getIdFromJWT(accessToken);

--- a/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtAuthenticationFilter.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtAuthenticationFilter.java
@@ -52,10 +52,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // header가 null이거나 빈 문자열이면 안됨.
         if (header != null && !header.equalsIgnoreCase("")) {
             if (header.startsWith("Bearer")) {
-                String access_token = header.split(" ")[1];
-                if (jwtTokenUtil.isValidateToken(access_token)) {
-                    Long memberId = jwtTokenUtil.getIdFromJWT(access_token);
-                    MemberRole role = MemberRole.valueOf(jwtTokenUtil.getRoleFromJWT(access_token));
+                String accessToken = header.split(" ")[1];
+                if (jwtTokenUtil.isValidateToken(accessToken)) {
+                    Long memberId = jwtTokenUtil.getIdFromJWT(accessToken);
+                    MemberRole role = MemberRole.valueOf(jwtTokenUtil.getRoleFromJWT(accessToken));
                     JwtToken jwtToken = new JwtToken(memberId, role);
                     SecurityContextHolder.getContext().setAuthentication(jwtToken);
                     filterChain.doFilter(request, response);

--- a/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtToken.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtToken.java
@@ -13,7 +13,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class JwtToken implements Authentication {
-    // TODO : Authentication을 상속받고 UserDetail을 상속받은 커스텀 유저 정보 객체 생성해줘야함.
     private Long memberId;
     private MemberRole memberRole;
 

--- a/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtToken.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtToken.java
@@ -14,7 +14,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class JwtToken implements Authentication {
     // TODO : Authentication을 상속받고 UserDetail을 상속받은 커스텀 유저 정보 객체 생성해줘야함.
-    private String memberId;
+    private Long memberId;
     private MemberRole memberRole;
 
     @Override

--- a/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtTokenEnums.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtTokenEnums.java
@@ -1,0 +1,12 @@
+package org.depromeet.spot.application.common.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum JwtTokenEnums {
+    BEARER("Bearer");
+
+    private final String value;
+}

--- a/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtTokenUtil.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtTokenUtil.java
@@ -10,6 +10,8 @@ import java.util.Map;
 
 import javax.crypto.spec.SecretKeySpec;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import org.depromeet.spot.domain.member.Member;
 import org.depromeet.spot.domain.member.enums.MemberRole;
 import org.springframework.beans.factory.annotation.Value;
@@ -118,5 +120,10 @@ public class JwtTokenUtil {
     private Key createSignature() {
         byte[] apiKeySecretBytes = SECRETKEY.getBytes();
         return new SecretKeySpec(apiKeySecretBytes, SignatureAlgorithm.HS256.getJcaName());
+    }
+
+    public String getAccessToken(HttpServletRequest request) {
+        String jwtToken = request.getHeader("Authorization");
+        return jwtToken.split(" ")[1];
     }
 }

--- a/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtTokenUtil.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtTokenUtil.java
@@ -54,20 +54,19 @@ public class JwtTokenUtil {
 
         return Jwts.builder()
                 .setHeader(createHeader())
-                .setClaims(createClaims(memberRole))
-                .setSubject(memberId.toString())
+                .setClaims(createClaims(memberId, memberRole))
                 .setIssuedAt(current)
                 .setExpiration(expiredAt)
                 .signWith(SignatureAlgorithm.HS256, SECRETKEY.getBytes())
                 .compact();
     }
 
-    public String getIdFromJWT(String token) {
+    public Long getIdFromJWT(String token) {
         return Jwts.parser()
                 .setSigningKey(SECRETKEY.getBytes())
                 .parseClaimsJws(token)
                 .getBody()
-                .get("id", String.class);
+                .get("memberId", Long.class);
     }
 
     public String getRoleFromJWT(String token) {
@@ -108,9 +107,10 @@ public class JwtTokenUtil {
     }
 
     // Claim -> 정보를 key-value 형태로 저장함.
-    private Map<String, Object> createClaims(MemberRole role) {
+    private Map<String, Object> createClaims(Long memberId, MemberRole role) {
         Map<String, Object> claims = new HashMap<>();
 
+        claims.put("memberId", memberId);
         claims.put("role", role);
         return claims;
     }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/oauth/OauthRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/oauth/OauthRepositoryImpl.java
@@ -18,6 +18,8 @@ import reactor.core.publisher.Mono;
 @Repository
 public class OauthRepositoryImpl implements OauthRepository {
 
+    private final String BEARER = "Bearer";
+
     // kakao에서 발급 받은 clientID
     @Value("${oauth.clientId}")
     private String CLIENT_ID;
@@ -93,7 +95,7 @@ public class OauthRepositoryImpl implements OauthRepository {
                                         uriBuilder.scheme("https").path("/v2/user/me").build(true))
                         .header(
                                 HttpHeaders.AUTHORIZATION,
-                                "Bearer " + accessToken) // access token 인가
+                                BEARER + " " + accessToken) // access token 인가
                         .header(
                                 HttpHeaders.CONTENT_TYPE,
                                 HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())


### PR DESCRIPTION
## ❗해당 PR 후에는 Jwt 토큰 형식이 약간 바뀌어서 이전 토큰은 사용 못 함❗

## 📌 개요 (필수)

- 헤더 jwt 토큰에서 memberId 가져오는 AOP 추가
- Jwt 토큰 형식 변경
- @MemberId 커스텀 어노테이션 추가

<br>

## 🔨 작업 사항 (필수)

- 헤더 jwt 토큰에서 memberId 가져오는 AOP 추가
- Jwt 토큰 형식 변경
  - memberId String -> Long 타입 변경
  - memberId Subject -> claim 으로 변경
- @MemberId 커스텀 어노테이션 추가
  - 메서드에 사용되는 커스텀 어노테이션 추가
  - 어노테이션 사용법 추가
    - 마우스 올리면 나옵니당
![image](https://github.com/user-attachments/assets/40e19b7d-1c59-4eae-99db-76a9a3e97a80)


<br>

## ⚡️ 관심 리뷰 (선택)

- 제대로 동작하는지 확인해줬으면 해요.
- Request body랑 query Param, path variable는 영향 안 주는지 확인 했는데 혹시 모르니 한 번 체크 부탁드립니당~~~
  - Header랑 request 자체를 건들어서 확인해봤어
  - Test용으로 GET과 POST 테스트를 했지만 처음 해보는 거라 걱정돼...ㅋㅋㅋ

<br>

## 💻 실행 화면 (필수)

- GET 테스트
![image](https://github.com/user-attachments/assets/f6fb807c-62eb-4444-bb63-a93dbfdb29d7)
![image](https://github.com/user-attachments/assets/d04e813c-4a05-4f72-a7a2-9346c1a889a2)

- POST 테스트
![image](https://github.com/user-attachments/assets/16180540-2380-4a07-b813-71449096d15a)
![image](https://github.com/user-attachments/assets/422e5566-f2ac-4e62-bcb8-d4b3d6a364f9)
