### PR TITLE
[BSVR-150] blockId, seatNumber를 이용하도록 리뷰 생성 API 수정

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/review/CreateReviewController.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/CreateReviewController.java
@@ -32,13 +32,14 @@ public class CreateReviewController {
     @CurrentMember
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "특정 좌석에 신규 리뷰를 추가한다.")
-    @PostMapping("/seats/{seatId}/reviews")
+    @PostMapping("/blocks/{blockId}/seats/{seatNumber}/reviews")
     public BaseReviewResponse create(
-            @PathVariable @Positive @NotNull final Long seatId,
+            @PathVariable @Positive @NotNull final Long blockId,
+            @PathVariable @Positive @NotNull final Integer seatNumber,
             @Parameter(hidden = true) Long memberId,
             @RequestBody @Valid @NotNull CreateReviewRequest request) {
         CreateReviewUsecase.CreateReviewResult result =
-                createReviewUsecase.create(seatId, memberId, request.toCommand());
+                createReviewUsecase.create(blockId, seatNumber, memberId, request.toCommand());
         return BaseReviewResponse.from(result.review());
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/seat/repository/SeatJpaRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/seat/repository/SeatJpaRepository.java
@@ -19,6 +19,16 @@ public interface SeatJpaRepository extends JpaRepository<SeatEntity, Long> {
                     + "where s.id = :id ")
     Optional<SeatEntity> findByIdWith(@Param("id") Long id);
 
+    @Query(
+            "SELECT s FROM SeatEntity s "
+                    + "JOIN FETCH s.stadium st "
+                    + "JOIN FETCH s.section sc "
+                    + "JOIN FETCH s.block b "
+                    + "JOIN FETCH s.row r "
+                    + "where s.block.id = :blockId and s.seatNumber = :seatNumber ")
+    Optional<SeatEntity> findByIdWith(
+            @Param("blockId") Long blockId, @Param("seatNumber") Integer seatNumber);
+
     List<SeatEntity> findAllByBlockId(Long blockId);
 
     List<SeatEntity> findAllBySectionId(Long sectionId);

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/seat/repository/SeatRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/seat/repository/SeatRepositoryImpl.java
@@ -41,6 +41,15 @@ public class SeatRepositoryImpl implements SeatRepository {
     }
 
     @Override
+    public Seat findByIdWith(Long blockId, Integer seatNumber) {
+        SeatEntity entity =
+                seatJpaRepository
+                        .findByIdWith(blockId, seatNumber)
+                        .orElseThrow(SeatNotFoundException::new);
+        return entity.toDomain();
+    }
+
+    @Override
     public Map<BlockRow, List<Seat>> findSeatsGroupByRowInBlock(Block block) {
         List<SeatEntity> entities = seatJpaRepository.findAllByBlockId(block.getId());
         List<Seat> seats = entities.stream().map(SeatEntity::toDomain).toList();

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/CreateReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/CreateReviewUsecase.java
@@ -10,7 +10,8 @@ import org.depromeet.spot.domain.seat.Seat;
 import lombok.Builder;
 
 public interface CreateReviewUsecase {
-    CreateReviewResult create(Long seatId, Long memberId, CreateReviewCommand command);
+    CreateReviewResult create(
+            Long blockId, Integer seatNumber, Long memberId, CreateReviewCommand command);
 
     @Builder
     record CreateReviewCommand(

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/seat/SeatRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/seat/SeatRepository.java
@@ -15,6 +15,8 @@ public interface SeatRepository {
 
     Seat findByIdWith(Long seatId);
 
+    Seat findByIdWith(Long blockId, Integer seatNumber);
+
     Map<BlockRow, List<Seat>> findSeatsGroupByRowInBlock(Block block);
 
     Map<BlockRow, List<Seat>> findSeatsGroupByRowInSection(Long sectionId);

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/CreateReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/CreateReviewService.java
@@ -1,7 +1,5 @@
 package org.depromeet.spot.usecase.service.review;
 
-// import org.depromeet.spot.common.exception.member.MemberException.MemberNotFoundException;
-// import org.depromeet.spot.common.exception.seat.SeatException.SeatNotFoundException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,10 +37,11 @@ public class CreateReviewService implements CreateReviewUsecase {
 
     @Override
     @Transactional
-    public CreateReviewResult create(Long seatId, Long memberId, CreateReviewCommand command) {
+    public CreateReviewResult create(
+            Long blockId, Integer seatNumber, Long memberId, CreateReviewCommand command) {
         // ToDo: orElseThrow not found exception 처리하기
         Member member = memberRepository.findById(memberId);
-        Seat seat = seatRepository.findByIdWith(seatId);
+        Seat seat = seatRepository.findByIdWith(blockId, seatNumber);
 
         // image와 keyword를 제외한 review 도메인 생성
         Review review = convertToDomain(seat, member, command);

--- a/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeSeatRepository.java
+++ b/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeSeatRepository.java
@@ -5,9 +5,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
+import org.depromeet.spot.common.exception.seat.SeatException.SeatNotFoundException;
 import org.depromeet.spot.domain.block.Block;
 import org.depromeet.spot.domain.block.BlockRow;
 import org.depromeet.spot.domain.seat.Seat;
@@ -25,7 +27,11 @@ public class FakeSeatRepository implements SeatRepository {
 
     @Override
     public Seat findById(Long seatId) {
-        return null;
+        return getById(seatId).orElseThrow(SeatNotFoundException::new);
+    }
+
+    private Optional<Seat> getById(Long id) {
+        return data.stream().filter(seat -> seat.getId().equals(id)).findAny();
     }
 
     @Override
@@ -64,6 +70,18 @@ public class FakeSeatRepository implements SeatRepository {
 
     @Override
     public Seat findByIdWith(Long seatId) {
-        return null;
+        return getById(seatId).orElseThrow(SeatNotFoundException::new);
+    }
+
+    @Override
+    public Seat findByIdWith(Long blockId, Integer seatNumber) {
+        return getByBlockAndSeatNum(seatNumber, blockId).orElseThrow(SeatNotFoundException::new);
+    }
+
+    private Optional<Seat> getByBlockAndSeatNum(Integer seatNumber, Long blockId) {
+        return data.stream()
+                .filter(seat -> seat.getBlock().getId().equals(blockId))
+                .filter(seat -> seat.getSeatNumber().equals(seatNumber))
+                .findAny();
     }
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- 클라이언트에서 seatId를 모르기 때문에, blockId와 seatNumber를 이용해 좌석을 추적하도록 수정해요.

<br>

## 🔨 작업 사항 (필수)

- seatId를 이용하던 API를 blockId, seatNumber를 이용하도록 수정

<br>

## 🌱 연관 내용 (선택)

- #71 로 스키마 변경 된 후에 실행 가능해용

<br>

## 💻 실행 화면 (필수)

성공
<img width="655" alt="스크린샷 2024-07-23 오후 10 05 12" src="https://github.com/user-attachments/assets/58b616ab-480c-4d39-a304-4abdf324bcdb">


실패 (블럭에 해당 좌석 없음)
<img width="728" alt="스크린샷 2024-07-23 오후 9 38 42" src="https://github.com/user-attachments/assets/a5081a20-565e-4dc9-9c46-62fa7112dc14">

