### PR TITLE
[BSVR-158] 내 리뷰 조회 API 사용자 정보 포함시키도록 업데이트

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/MyReviewListResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/MyReviewListResponse.java
@@ -5,9 +5,11 @@ import java.util.stream.Collectors;
 
 import org.depromeet.spot.application.review.dto.response.BlockReviewListResponse.FilterInfo;
 import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.MemberInfoOnMyReviewResult;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.MyReviewListResult;
 
 public record MyReviewListResponse(
+        MemberInfoOnMyReviewResult memberInfoOnMyReview,
         List<MyReviewResponse> reviews,
         long totalElements,
         int totalPages,
@@ -18,6 +20,7 @@ public record MyReviewListResponse(
         FilterInfo filter) {
     public static MyReviewListResponse from(
             MyReviewListResult result, Integer year, Integer month) {
+
         List<MyReviewResponse> reviews =
                 result.reviews().stream().map(MyReviewResponse::from).collect(Collectors.toList());
         FilterInfo filter = new FilterInfo(null, null, year, month);
@@ -25,6 +28,7 @@ public record MyReviewListResponse(
         boolean first = result.number() == 0;
         boolean last = result.number() == result.totalPages() - 1;
         return new MyReviewListResponse(
+                result.memberInfoOnMyReviewResult(),
                 reviews,
                 result.totalElements(),
                 result.totalPages(),

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
@@ -40,5 +40,18 @@ public interface ReadReviewUsecase {
 
     @Builder
     record MyReviewListResult(
-            List<Review> reviews, long totalElements, int totalPages, int number, int size) {}
+            MemberInfoOnMyReviewResult memberInfoOnMyReviewResult,
+            List<Review> reviews,
+            long totalElements,
+            int totalPages,
+            int number,
+            int size) {}
+
+    @Builder
+    record MemberInfoOnMyReviewResult(
+            Long userId,
+            String profileImageUrl,
+            Integer level,
+            String nickname,
+            Long reviewCount) {}
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -79,7 +79,11 @@ public class ReadReviewService implements ReadReviewUsecase {
 
         List<Review> reviewsWithKeywords = mapKeywordsToReviews(reviewPage.getContent());
 
+        MemberInfoOnMyReviewResult memberInfo =
+                createMemberInfoFromReviews(reviewsWithKeywords, reviewPage.getTotalElements());
+
         return MyReviewListResult.builder()
+                .memberInfoOnMyReviewResult(memberInfo)
                 .reviews(reviewsWithKeywords)
                 .totalElements(reviewPage.getTotalElements())
                 .totalPages(reviewPage.getTotalPages())
@@ -91,6 +95,22 @@ public class ReadReviewService implements ReadReviewUsecase {
     @Override
     public List<ReviewYearMonth> findReviewMonths(Long memberId) {
         return reviewRepository.findReviewMonthsByMemberId(memberId);
+    }
+
+    private MemberInfoOnMyReviewResult createMemberInfoFromReviews(
+            List<Review> reviews, long totalReviewCount) {
+        if (reviews.isEmpty()) {
+            return null;
+        }
+
+        Review firstReview = reviews.get(0);
+        return MemberInfoOnMyReviewResult.builder()
+                .userId(firstReview.getMember().getId())
+                .profileImageUrl(firstReview.getMember().getProfileImage())
+                .level(firstReview.getMember().getLevel())
+                .nickname(firstReview.getMember().getNickname())
+                .reviewCount(totalReviewCount)
+                .build();
     }
 
     private List<Review> mapKeywordsToReviews(List<Review> reviews) {


### PR DESCRIPTION
## 📌 개요 (필수)

- PR 요약

<br>

## 🔨 작업 사항 (필수)

- 내 리뷰 조회 때 아래 항목을 포함시켜 반환한다.
1. 유저 id
2. 프로필 사진
3. 레벨
4. 닉네임
5. 작성한 총 리뷰 개수


<br>

## ⚡️ 관심 리뷰 (선택)

@EunjiShin @wjdwnsdnjs13 
- 여기 주황색 부분에 레벨 옆에 있는 "전설의 직관러" 이건 닉네임이 아니라 칭호같지 않아?
- 칭호 지정에 대한 부분을 내가 놓쳤나? Member 테이블에는 따로 정의되어 있지 않은 것 같아서

![image](https://github.com/user-attachments/assets/26e1ae6b-9ae4-48c2-8877-ee47a7908846)

<br>

## 💻 실행 화면 (필수)

- memberInfoOnMyReview 부분이 이번 수정때 새롭게 업데이트 된 부분이다!

![image](https://github.com/user-attachments/assets/bbcca5ab-15c5-4782-996c-bc906044ce73)
