### PR TITLE
[BSVR-159] 리뷰 삭제 API 구현 (soft delete)

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/review/DeleteReviewController.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/DeleteReviewController.java
@@ -1,8 +1,17 @@
 package org.depromeet.spot.application.review;
 
+import org.depromeet.spot.application.common.annotation.CurrentMember;
+import org.depromeet.spot.application.review.dto.response.DeleteResponse;
+import org.depromeet.spot.usecase.port.in.review.DeleteReviewUsecase;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -10,4 +19,18 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "리뷰")
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
-public class DeleteReviewController {}
+public class DeleteReviewController {
+
+    private final DeleteReviewUsecase deleteReviewUsecase;
+
+    @CurrentMember
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "리뷰를 삭제한다. (soft delete)")
+    @DeleteMapping("/reviews/{reviewId}")
+    public DeleteResponse deleteReview(
+            @PathVariable Long reviewId, @Parameter(hidden = true) Long memberId) {
+        Long deletedReviewId = deleteReviewUsecase.deleteReview(reviewId, memberId);
+
+        return DeleteResponse.from(deletedReviewId);
+    }
+}

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/DeleteResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/DeleteResponse.java
@@ -1,0 +1,7 @@
+package org.depromeet.spot.application.review.dto.response;
+
+public record DeleteResponse(Long deletedReviewId) {
+    public static DeleteResponse from(Long id) {
+        return new DeleteResponse(id);
+    }
+}

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/MyReviewListResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/MyReviewListResponse.java
@@ -5,9 +5,11 @@ import java.util.stream.Collectors;
 
 import org.depromeet.spot.application.review.dto.response.BlockReviewListResponse.FilterInfo;
 import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.MemberInfoOnMyReviewResult;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.MyReviewListResult;
 
 public record MyReviewListResponse(
+        MemberInfoOnMyReviewResult memberInfoOnMyReview,
         List<MyReviewResponse> reviews,
         long totalElements,
         int totalPages,
@@ -18,6 +20,7 @@ public record MyReviewListResponse(
         FilterInfo filter) {
     public static MyReviewListResponse from(
             MyReviewListResult result, Integer year, Integer month) {
+
         List<MyReviewResponse> reviews =
                 result.reviews().stream().map(MyReviewResponse::from).collect(Collectors.toList());
         FilterInfo filter = new FilterInfo(null, null, year, month);
@@ -25,6 +28,7 @@ public record MyReviewListResponse(
         boolean first = result.number() == 0;
         boolean last = result.number() == result.totalPages() - 1;
         return new MyReviewListResponse(
+                result.memberInfoOnMyReviewResult(),
                 reviews,
                 result.totalElements(),
                 result.totalPages(),

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewJpaRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewJpaRepository.java
@@ -1,5 +1,6 @@
 package org.depromeet.spot.jpa.review.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.depromeet.spot.domain.review.ReviewYearMonth;
@@ -50,6 +51,10 @@ public interface ReviewJpaRepository extends JpaRepository<ReviewEntity, Long> {
     List<ReviewYearMonth> findReviewMonthsByMemberId(@Param("memberId") Long memberId);
 
     @Modifying
-    @Query("UPDATE ReviewEntity r SET r.deletedAt = CURRENT_TIMESTAMP WHERE r.id = :reviewId")
-    void softDeleteById(@Param("reviewId") Long reviewId);
+    @Query(
+            "UPDATE ReviewEntity r SET r.deletedAt = :deletedAt WHERE r.id = :reviewId AND r.member.id = :memberId AND r.deletedAt IS NULL")
+    int softDeleteByIdAndMemberId(
+            @Param("reviewId") Long reviewId,
+            @Param("memberId") Long memberId,
+            @Param("deletedAt") LocalDateTime deletedAt);
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewRepositoryImpl.java
@@ -1,5 +1,6 @@
 package org.depromeet.spot.jpa.review.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -10,7 +11,6 @@ import org.depromeet.spot.usecase.port.out.review.ReviewRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -67,8 +67,13 @@ public class ReviewRepositoryImpl implements ReviewRepository {
     }
 
     @Override
-    @Transactional
-    public void deleteReview(Long reviewId) {
-        reviewJpaRepository.softDeleteById(reviewId);
+    public Long softDeleteByIdAndMemberId(Long reviewId, Long memberId) {
+        int updatedCount =
+                reviewJpaRepository.softDeleteByIdAndMemberId(
+                        reviewId, memberId, LocalDateTime.now());
+        if (updatedCount == 0) {
+            throw new IllegalArgumentException("Review not found or not owned by the member");
+        }
+        return reviewId;
     }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/DeleteReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/DeleteReviewUsecase.java
@@ -1,0 +1,6 @@
+package org.depromeet.spot.usecase.port.in.review;
+
+public interface DeleteReviewUsecase {
+
+    Long deleteReview(Long reviewId, Long memberId);
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
@@ -40,5 +40,18 @@ public interface ReadReviewUsecase {
 
     @Builder
     record MyReviewListResult(
-            List<Review> reviews, long totalElements, int totalPages, int number, int size) {}
+            MemberInfoOnMyReviewResult memberInfoOnMyReviewResult,
+            List<Review> reviews,
+            long totalElements,
+            int totalPages,
+            int number,
+            int size) {}
+
+    @Builder
+    record MemberInfoOnMyReviewResult(
+            Long userId,
+            String profileImageUrl,
+            Integer level,
+            String nickname,
+            Long reviewCount) {}
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewRepository.java
@@ -28,5 +28,5 @@ public interface ReviewRepository {
 
     List<ReviewYearMonth> findReviewMonthsByMemberId(Long memberId);
 
-    void deleteReview(Long reviewId);
+    Long softDeleteByIdAndMemberId(Long reviewId, Long memberId);
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/DeleteReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/DeleteReviewService.java
@@ -1,0 +1,21 @@
+package org.depromeet.spot.usecase.service.review;
+
+import org.depromeet.spot.usecase.port.in.review.DeleteReviewUsecase;
+import org.depromeet.spot.usecase.port.out.review.ReviewRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteReviewService implements DeleteReviewUsecase {
+
+    private final ReviewRepository reviewRepository;
+
+    @Override
+    @Transactional
+    public Long deleteReview(Long reviewId, Long memberId) {
+        return reviewRepository.softDeleteByIdAndMemberId(reviewId, memberId);
+    }
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -79,7 +79,11 @@ public class ReadReviewService implements ReadReviewUsecase {
 
         List<Review> reviewsWithKeywords = mapKeywordsToReviews(reviewPage.getContent());
 
+        MemberInfoOnMyReviewResult memberInfo =
+                createMemberInfoFromReviews(reviewsWithKeywords, reviewPage.getTotalElements());
+
         return MyReviewListResult.builder()
+                .memberInfoOnMyReviewResult(memberInfo)
                 .reviews(reviewsWithKeywords)
                 .totalElements(reviewPage.getTotalElements())
                 .totalPages(reviewPage.getTotalPages())
@@ -91,6 +95,22 @@ public class ReadReviewService implements ReadReviewUsecase {
     @Override
     public List<ReviewYearMonth> findReviewMonths(Long memberId) {
         return reviewRepository.findReviewMonthsByMemberId(memberId);
+    }
+
+    private MemberInfoOnMyReviewResult createMemberInfoFromReviews(
+            List<Review> reviews, long totalReviewCount) {
+        if (reviews.isEmpty()) {
+            return null;
+        }
+
+        Review firstReview = reviews.get(0);
+        return MemberInfoOnMyReviewResult.builder()
+                .userId(firstReview.getMember().getId())
+                .profileImageUrl(firstReview.getMember().getProfileImage())
+                .level(firstReview.getMember().getLevel())
+                .nickname(firstReview.getMember().getNickname())
+                .reviewCount(totalReviewCount)
+                .build();
     }
 
     private List<Review> mapKeywordsToReviews(List<Review> reviews) {


### PR DESCRIPTION
## 📌 개요 (필수)

- 리뷰 삭제 API를 구현
<br>

## 🔨 작업 사항 (필수)

- soft delete 방식을 사용해 리뷰를 삭제하는 API를 구현했어요.
- 엄밀히 말하면 삭제가 아닌 deleted_at 값을 업데이트!
- 삭제는 신중해야하기 때문에 aos는 review pk만 요청으로 보내지만 토큰의 memberId도 가지고 와서 이 두개를 함꼐 사용해 리뷰를 삭제해줬어요.
- 조회할 때 deleted_at이 null인 것만 조회하도록 업데이트를 해야하지만 이미 등록할 때 잘 처리해뒀어요~

<br>

## 💻 실행 화면 (필수)

- 잘 삭제 된다!

![image](https://github.com/user-attachments/assets/6929c48b-f866-4708-91e2-209980a5e16a)


- 삭제한 리뷰에만 deleted_at 컬럼에 지운 날짜가 들어간 것을 확인!

![image](https://github.com/user-attachments/assets/5b38ed28-cb5c-4e62-b6cd-40e0b33cb290)
