### PR TITLE
[BSVR-159] level 칭호 기능 추가

### DIFF
--- a/.github/workflows/dev-build-and-deploy.yaml
+++ b/.github/workflows/dev-build-and-deploy.yaml
@@ -115,7 +115,7 @@ jobs:
                       -e OAUTH_CLIENTID=${{ secrets.KAKAO_CLIENT_ID }} \
                       -e OAUTH_KAUTHTOKENURLHOST=${{ secrets.KAUTH_TOKEN_URL_HOST }} \
                       -e OAUTH_KAUTHUSERURLHOST=${{ secrets.KAUTH_USER_URL_HOST }} \
-                      -e SPRING_JPA_HIBERNATE_DDL_AUTO=validate \
+                      -e SPRING_JPA_HIBERNATE_DDL_AUTO=update \
                       -e NCP_OBJECT_STORAGE_ACCESS_KEY=${{ secrets.NCP_OBJECT_STORAGE_ACCESS_KEY }} \
                       -e NCP_OBJECT_STORAGE_SECRET_KEY=${{ secrets.NCP_OBJECT_STORAGE_SECRET_KEY }} \
                       -e TZ=Asia/Seoul \

--- a/.github/workflows/dev-build-and-deploy.yaml
+++ b/.github/workflows/dev-build-and-deploy.yaml
@@ -72,7 +72,7 @@ jobs:
 
   deploy:
       needs: build-and-test
-#      if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push'
+      if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push'
       runs-on: ubuntu-latest
 
       steps:
@@ -115,6 +115,7 @@ jobs:
                       -e OAUTH_CLIENTID=${{ secrets.KAKAO_CLIENT_ID }} \
                       -e OAUTH_KAUTHTOKENURLHOST=${{ secrets.KAUTH_TOKEN_URL_HOST }} \
                       -e OAUTH_KAUTHUSERURLHOST=${{ secrets.KAUTH_USER_URL_HOST }} \
+                      -e SPRING_JPA_HIBERNATE_DDL_AUTO=validate \
                       -e NCP_OBJECT_STORAGE_ACCESS_KEY=${{ secrets.NCP_OBJECT_STORAGE_ACCESS_KEY }} \
                       -e NCP_OBJECT_STORAGE_SECRET_KEY=${{ secrets.NCP_OBJECT_STORAGE_SECRET_KEY }} \
                       -e TZ=Asia/Seoul \

--- a/.github/workflows/dev-build-and-deploy.yaml
+++ b/.github/workflows/dev-build-and-deploy.yaml
@@ -72,7 +72,7 @@ jobs:
 
   deploy:
       needs: build-and-test
-      if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push'
+#      if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push'
       runs-on: ubuntu-latest
 
       steps:
@@ -115,7 +115,6 @@ jobs:
                       -e OAUTH_CLIENTID=${{ secrets.KAKAO_CLIENT_ID }} \
                       -e OAUTH_KAUTHTOKENURLHOST=${{ secrets.KAUTH_TOKEN_URL_HOST }} \
                       -e OAUTH_KAUTHUSERURLHOST=${{ secrets.KAUTH_USER_URL_HOST }} \
-                      -e SPRING_JPA_HIBERNATE_DDL_AUTO=update \
                       -e NCP_OBJECT_STORAGE_ACCESS_KEY=${{ secrets.NCP_OBJECT_STORAGE_ACCESS_KEY }} \
                       -e NCP_OBJECT_STORAGE_SECRET_KEY=${{ secrets.NCP_OBJECT_STORAGE_SECRET_KEY }} \
                       -e TZ=Asia/Seoul \
@@ -144,3 +143,4 @@ jobs:
                 tag: ${{ steps.tag_version.outputs.new_tag }}
                 name: Release ${{ steps.tag_version.outputs.new_tag }}
                 body: ${{ steps.tag_version.outputs.changelog }}
+

--- a/application/src/main/java/org/depromeet/spot/application/member/controller/MemberController.java
+++ b/application/src/main/java/org/depromeet/spot/application/member/controller/MemberController.java
@@ -69,12 +69,11 @@ public class MemberController {
     @GetMapping("/duplicatedNickname/{nickname}")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "닉네임 중복확인 API")
-    public Boolean duplicatedNickname(
+    public boolean duplicatedNickname(
             @PathVariable("nickname")
                     @Parameter(name = "nickname", description = "닉네임", required = true)
                     String nickname) {
-        Boolean result = memberUsecase.duplicatedNickname(nickname);
-        return result;
+        return memberUsecase.duplicatedNickname(nickname);
     }
 
     @GetMapping("/accessToken/{idCode}")
@@ -104,6 +103,7 @@ public class MemberController {
     @CurrentMember
     @GetMapping("/memberInfo")
     @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "로그인 유저 정보 조회 API")
     public MyHomeResponse findMemberInfo(@Parameter(hidden = true) Long memberId) {
         MemberInfo memberInfo = memberUsecase.findMemberInfo(memberId);
 

--- a/application/src/main/java/org/depromeet/spot/application/member/controller/MemberController.java
+++ b/application/src/main/java/org/depromeet/spot/application/member/controller/MemberController.java
@@ -2,11 +2,14 @@ package org.depromeet.spot.application.member.controller;
 
 import jakarta.validation.Valid;
 
+import org.depromeet.spot.application.common.annotation.CurrentMember;
 import org.depromeet.spot.application.common.jwt.JwtTokenUtil;
 import org.depromeet.spot.application.member.dto.request.RegisterReq;
 import org.depromeet.spot.application.member.dto.response.JwtTokenResponse;
+import org.depromeet.spot.application.member.dto.response.MyHomeResponse;
 import org.depromeet.spot.domain.member.Member;
 import org.depromeet.spot.usecase.port.in.member.MemberUsecase;
+import org.depromeet.spot.usecase.port.in.member.MemberUsecase.MemberInfo;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -96,5 +99,14 @@ public class MemberController {
                     String accessToken) {
         // TODO : (개발용) 유저 탈퇴 아님! 단순 유저 삭제만 진행함.
         return memberUsecase.deleteMember(accessToken);
+    }
+
+    @CurrentMember
+    @GetMapping("/memberInfo")
+    @ResponseStatus(HttpStatus.OK)
+    public MyHomeResponse findMemberInfo(@Parameter(hidden = true) Long memberId) {
+        MemberInfo memberInfo = memberUsecase.findMemberInfo(memberId);
+
+        return MyHomeResponse.from(memberInfo);
     }
 }

--- a/application/src/main/java/org/depromeet/spot/application/member/dto/response/MyHomeResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/member/dto/response/MyHomeResponse.java
@@ -1,0 +1,18 @@
+package org.depromeet.spot.application.member.dto.response;
+
+import org.depromeet.spot.usecase.port.in.member.MemberUsecase.MemberInfo;
+
+import lombok.Builder;
+
+@Builder
+public record MyHomeResponse(
+        String profileImageUrl, String nickname, Integer level, String teamImageUrl) {
+    public static MyHomeResponse from(MemberInfo memberInfo) {
+        return MyHomeResponse.builder()
+                .profileImageUrl(memberInfo.getMember().getProfileImage())
+                .nickname(memberInfo.getMember().getNickname())
+                .level(memberInfo.getMember().getLevel())
+                .teamImageUrl(memberInfo.getBaseballTeam().getLogo())
+                .build();
+    }
+}

--- a/application/src/main/java/org/depromeet/spot/application/member/dto/response/MyHomeResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/member/dto/response/MyHomeResponse.java
@@ -6,13 +6,19 @@ import lombok.Builder;
 
 @Builder
 public record MyHomeResponse(
-        String profileImageUrl, String nickname, Integer level, String teamImageUrl) {
+        String profileImageUrl,
+        String nickname,
+        Integer level,
+        String levelTitle,
+        String teamImageUrl) {
+
     public static MyHomeResponse from(MemberInfo memberInfo) {
         return MyHomeResponse.builder()
-                .profileImageUrl(memberInfo.getMember().getProfileImage())
-                .nickname(memberInfo.getMember().getNickname())
-                .level(memberInfo.getMember().getLevel())
-                .teamImageUrl(memberInfo.getBaseballTeam().getLogo())
+                .profileImageUrl(memberInfo.getProfileImageUrl())
+                .nickname(memberInfo.getNickname())
+                .level(memberInfo.getLevel())
+                .levelTitle(memberInfo.getLevelTitle())
+                .teamImageUrl(memberInfo.getTeamImageUrl())
                 .build();
     }
 }

--- a/application/src/main/java/org/depromeet/spot/application/review/CreateReviewController.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/CreateReviewController.java
@@ -32,13 +32,14 @@ public class CreateReviewController {
     @CurrentMember
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "특정 좌석에 신규 리뷰를 추가한다.")
-    @PostMapping("/seats/{seatId}/reviews")
+    @PostMapping("/blocks/{blockId}/seats/{seatNumber}/reviews")
     public BaseReviewResponse create(
-            @PathVariable @Positive @NotNull final Long seatId,
+            @PathVariable @Positive @NotNull final Long blockId,
+            @PathVariable @Positive @NotNull final Integer seatNumber,
             @Parameter(hidden = true) Long memberId,
             @RequestBody @Valid @NotNull CreateReviewRequest request) {
         CreateReviewUsecase.CreateReviewResult result =
-                createReviewUsecase.create(seatId, memberId, request.toCommand());
+                createReviewUsecase.create(blockId, seatNumber, memberId, request.toCommand());
         return BaseReviewResponse.from(result.review());
     }
 }

--- a/common/src/main/java/org/depromeet/spot/common/exception/member/MemberErrorCode.java
+++ b/common/src/main/java/org/depromeet/spot/common/exception/member/MemberErrorCode.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 public enum MemberErrorCode implements ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "요청 유저가 존재하지 않습니다."),
     MEMBER_NICKNAME_CONFLICT(HttpStatus.CONFLICT, "M002", "닉네임이 중복됩니다."),
+    INVALID_LEVEL(HttpStatus.INTERNAL_SERVER_ERROR, "M003", "잘못된 레벨입니다."),
     ;
 
     private final HttpStatus status;

--- a/common/src/main/java/org/depromeet/spot/common/exception/member/MemberException.java
+++ b/common/src/main/java/org/depromeet/spot/common/exception/member/MemberException.java
@@ -23,4 +23,10 @@ public abstract class MemberException extends BusinessException {
             super(MemberErrorCode.MEMBER_NICKNAME_CONFLICT);
         }
     }
+
+    public static class InvalidLevelException extends MemberException {
+        public InvalidLevelException() {
+            super(MemberErrorCode.INVALID_LEVEL);
+        }
+    }
 }

--- a/domain/src/main/java/org/depromeet/spot/domain/member/enums/Level.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/member/enums/Level.java
@@ -1,0 +1,37 @@
+package org.depromeet.spot.domain.member.enums;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.depromeet.spot.common.exception.member.MemberException.InvalidLevelException;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Level {
+    LEVEL_1(1, "직관 첫 걸음"),
+    LEVEL_2(2, "경기장 탐험가"),
+    LEVEL_3(3, "직관의 여유"),
+    LEVEL_4(4, "응원 단장"),
+    LEVEL_5(5, "야구장 VIP"),
+    LEVEL_6(6, "전설의 직관러"),
+    ;
+
+    private final int level;
+    private final String title;
+
+    private static final Map<Integer, String> levelTitleMap =
+            Arrays.stream(Level.values())
+                    .collect(Collectors.toMap(info -> info.level, info -> info.title));
+
+    public static String getTitleFrom(final int level) {
+        String title = levelTitleMap.get(level);
+        if (title == null) {
+            throw new InvalidLevelException();
+        }
+        return title;
+    }
+}

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberJpaRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberJpaRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
     Optional<MemberEntity> findByIdToken(String idToken);
 
-    Boolean existsByNickname(String nickname);
+    boolean existsByNickname(String nickname);
 
     @Modifying
     @Query(

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberRepositoryImpl.java
@@ -41,7 +41,7 @@ public class MemberRepositoryImpl implements MemberRepository {
     }
 
     @Override
-    public Boolean existsByNickname(String nickname) {
+    public boolean existsByNickname(String nickname) {
         return memberJpaRepository.existsByNickname(nickname);
     }
 

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/seat/repository/SeatJpaRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/seat/repository/SeatJpaRepository.java
@@ -19,6 +19,16 @@ public interface SeatJpaRepository extends JpaRepository<SeatEntity, Long> {
                     + "where s.id = :id ")
     Optional<SeatEntity> findByIdWith(@Param("id") Long id);
 
+    @Query(
+            "SELECT s FROM SeatEntity s "
+                    + "JOIN FETCH s.stadium st "
+                    + "JOIN FETCH s.section sc "
+                    + "JOIN FETCH s.block b "
+                    + "JOIN FETCH s.row r "
+                    + "where s.block.id = :blockId and s.seatNumber = :seatNumber ")
+    Optional<SeatEntity> findByIdWith(
+            @Param("blockId") Long blockId, @Param("seatNumber") Integer seatNumber);
+
     List<SeatEntity> findAllByBlockId(Long blockId);
 
     List<SeatEntity> findAllBySectionId(Long sectionId);

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/seat/repository/SeatRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/seat/repository/SeatRepositoryImpl.java
@@ -41,6 +41,15 @@ public class SeatRepositoryImpl implements SeatRepository {
     }
 
     @Override
+    public Seat findByIdWith(Long blockId, Integer seatNumber) {
+        SeatEntity entity =
+                seatJpaRepository
+                        .findByIdWith(blockId, seatNumber)
+                        .orElseThrow(SeatNotFoundException::new);
+        return entity.toDomain();
+    }
+
+    @Override
     public Map<BlockRow, List<Seat>> findSeatsGroupByRowInBlock(Block block) {
         List<SeatEntity> entities = seatJpaRepository.findAllByBlockId(block.getId());
         List<Seat> seats = entities.stream().map(SeatEntity::toDomain).toList();

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/member/MemberUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/member/MemberUsecase.java
@@ -1,6 +1,11 @@
 package org.depromeet.spot.usecase.port.in.member;
 
 import org.depromeet.spot.domain.member.Member;
+import org.depromeet.spot.domain.team.BaseballTeam;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 
 public interface MemberUsecase {
 
@@ -13,4 +18,18 @@ public interface MemberUsecase {
     String getAccessToken(String idCode);
 
     Boolean deleteMember(String accessToken);
+
+    MemberInfo findMemberInfo(Long memberId);
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    class MemberInfo {
+        Member member;
+        BaseballTeam baseballTeam;
+
+        public static MemberInfo of(Member member, BaseballTeam baseballTeam) {
+            return MemberInfo.builder().member(member).baseballTeam(baseballTeam).build();
+        }
+    }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/member/MemberUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/member/MemberUsecase.java
@@ -1,6 +1,7 @@
 package org.depromeet.spot.usecase.port.in.member;
 
 import org.depromeet.spot.domain.member.Member;
+import org.depromeet.spot.domain.member.enums.Level;
 import org.depromeet.spot.domain.team.BaseballTeam;
 
 import lombok.AllArgsConstructor;
@@ -13,11 +14,11 @@ public interface MemberUsecase {
 
     Member login(String idCode);
 
-    Boolean duplicatedNickname(String nickname);
+    boolean duplicatedNickname(String nickname);
 
     String getAccessToken(String idCode);
 
-    Boolean deleteMember(String accessToken);
+    boolean deleteMember(String accessToken);
 
     MemberInfo findMemberInfo(Long memberId);
 
@@ -25,11 +26,21 @@ public interface MemberUsecase {
     @Builder
     @AllArgsConstructor
     class MemberInfo {
-        Member member;
-        BaseballTeam baseballTeam;
+        private final String nickname;
+        private final String profileImageUrl;
+        private final int level;
+        private final String levelTitle;
+        private String teamImageUrl;
 
         public static MemberInfo of(Member member, BaseballTeam baseballTeam) {
-            return MemberInfo.builder().member(member).baseballTeam(baseballTeam).build();
+            final int level = member.getLevel();
+            return MemberInfo.builder()
+                    .nickname(member.getNickname())
+                    .profileImageUrl(member.getProfileImage())
+                    .level(level)
+                    .levelTitle(Level.getTitleFrom(level))
+                    .teamImageUrl(baseballTeam.getLogo())
+                    .build();
         }
     }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/CreateReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/CreateReviewUsecase.java
@@ -10,7 +10,8 @@ import org.depromeet.spot.domain.seat.Seat;
 import lombok.Builder;
 
 public interface CreateReviewUsecase {
-    CreateReviewResult create(Long seatId, Long memberId, CreateReviewCommand command);
+    CreateReviewResult create(
+            Long blockId, Integer seatNumber, Long memberId, CreateReviewCommand command);
 
     @Builder
     record CreateReviewCommand(

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/member/MemberRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/member/MemberRepository.java
@@ -14,7 +14,7 @@ public interface MemberRepository {
 
     Optional<Member> findByIdToken(String idToken);
 
-    Boolean existsByNickname(String nickname);
+    boolean existsByNickname(String nickname);
 
     Member findById(Long memberId);
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/seat/SeatRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/seat/SeatRepository.java
@@ -15,6 +15,8 @@ public interface SeatRepository {
 
     Seat findByIdWith(Long seatId);
 
+    Seat findByIdWith(Long blockId, Integer seatNumber);
+
     Map<BlockRow, List<Seat>> findSeatsGroupByRowInBlock(Block block);
 
     Map<BlockRow, List<Seat>> findSeatsGroupByRowInSection(Long sectionId);

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/member/MemberService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/member/MemberService.java
@@ -56,10 +56,10 @@ public class MemberService implements MemberUsecase {
     }
 
     @Override
-    public Boolean duplicatedNickname(String nickname) {
+    public boolean duplicatedNickname(String nickname) {
         if (memberRepository.existsByNickname(nickname))
             throw new MemberNicknameConflictException();
-        return Boolean.FALSE;
+        return false;
     }
 
     @Override
@@ -69,7 +69,7 @@ public class MemberService implements MemberUsecase {
 
     @Transactional
     @Override
-    public Boolean deleteMember(String accessToken) {
+    public boolean deleteMember(String accessToken) {
         Member memberResult = oauthRepository.getLoginUserInfo(accessToken);
         Optional<Member> existedMember = memberRepository.findByIdToken(memberResult.getIdToken());
 
@@ -78,7 +78,7 @@ public class MemberService implements MemberUsecase {
             throw new MemberNotFoundException();
         }
         memberRepository.deleteByIdToken(memberResult.getIdToken());
-        return Boolean.TRUE;
+        return true;
     }
 
     @Transactional(readOnly = true)

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/CreateReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/CreateReviewService.java
@@ -1,7 +1,5 @@
 package org.depromeet.spot.usecase.service.review;
 
-// import org.depromeet.spot.common.exception.member.MemberException.MemberNotFoundException;
-// import org.depromeet.spot.common.exception.seat.SeatException.SeatNotFoundException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,10 +37,11 @@ public class CreateReviewService implements CreateReviewUsecase {
 
     @Override
     @Transactional
-    public CreateReviewResult create(Long seatId, Long memberId, CreateReviewCommand command) {
+    public CreateReviewResult create(
+            Long blockId, Integer seatNumber, Long memberId, CreateReviewCommand command) {
         // ToDo: orElseThrow not found exception 처리하기
         Member member = memberRepository.findById(memberId);
-        Seat seat = seatRepository.findByIdWith(seatId);
+        Seat seat = seatRepository.findByIdWith(blockId, seatNumber);
 
         // image와 keyword를 제외한 review 도메인 생성
         Review review = convertToDomain(seat, member, command);

--- a/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeSeatRepository.java
+++ b/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeSeatRepository.java
@@ -5,9 +5,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
+import org.depromeet.spot.common.exception.seat.SeatException.SeatNotFoundException;
 import org.depromeet.spot.domain.block.Block;
 import org.depromeet.spot.domain.block.BlockRow;
 import org.depromeet.spot.domain.seat.Seat;
@@ -25,7 +27,11 @@ public class FakeSeatRepository implements SeatRepository {
 
     @Override
     public Seat findById(Long seatId) {
-        return null;
+        return getById(seatId).orElseThrow(SeatNotFoundException::new);
+    }
+
+    private Optional<Seat> getById(Long id) {
+        return data.stream().filter(seat -> seat.getId().equals(id)).findAny();
     }
 
     @Override
@@ -64,6 +70,18 @@ public class FakeSeatRepository implements SeatRepository {
 
     @Override
     public Seat findByIdWith(Long seatId) {
-        return null;
+        return getById(seatId).orElseThrow(SeatNotFoundException::new);
+    }
+
+    @Override
+    public Seat findByIdWith(Long blockId, Integer seatNumber) {
+        return getByBlockAndSeatNum(seatNumber, blockId).orElseThrow(SeatNotFoundException::new);
+    }
+
+    private Optional<Seat> getByBlockAndSeatNum(Integer seatNumber, Long blockId) {
+        return data.stream()
+                .filter(seat -> seat.getBlock().getId().equals(blockId))
+                .filter(seat -> seat.getSeatNumber().equals(seatNumber))
+                .findAny();
     }
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- 유저 레벨별 칭호를 관리하고, 내 정보 조회 API response에 추가해요.

<br>

## 🔨 작업 사항 (필수)

- 레벨-칭호 관리 enum 추가
- 내 정보 조회 API res에 칭호 정보 추가

<br>

## 🌱 연관 내용 (선택)

- [브랜치 한번 꼬여서](https://github.com/depromeet/SPOT-server/pull/78#issuecomment-2246849916), 리뷰 삭제 관련 작업물들까지 포함되었어요! 참고해주세용
- [aos와의 논의 스레드](https://depromeet-15th.slack.com/archives/C076JJKKR4H/p1721790310475679)
- 1차땐 칭호만 있어서 빠른 작업을 위해 enum으로 만들었어요.
  - 레벨에 맞는 string만 리턴하면 되는데, DB에 저장하는건 현재 요구사항에 비해 공수가 너무 크다고 판단
    - DB 테이블로 분리하면 -> 멤버가 level 테이블을 참조해야하고 (DB 테이블, 엔티티, 도메인 변경 필요), 기존에 작성된 쿼리들도 수정해야 함
  - 2차때 레벨별 그래픽이 추가될 예정이니, 그때 테이블로 분리하면 될 것 같아요.

<br>

## 💻 실행 화면 (필수)
<img width="1077" alt="스크린샷 2024-07-24 오후 1 50 19" src="https://github.com/user-attachments/assets/ec2b9f44-4c36-48a2-b64c-e79f5ef0f9a2">
