### PR TITLE
[BSVR-161] 내 리뷰 조회 API response에 칭호 추가

### DIFF
--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
@@ -52,6 +52,7 @@ public interface ReadReviewUsecase {
             Long userId,
             String profileImageUrl,
             Integer level,
+            String levelTitle,
             String nickname,
             Long reviewCount) {}
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.depromeet.spot.domain.member.enums.Level;
 import org.depromeet.spot.domain.review.Review;
 import org.depromeet.spot.domain.review.ReviewYearMonth;
 import org.depromeet.spot.domain.review.image.TopReviewImage;
@@ -108,6 +109,7 @@ public class ReadReviewService implements ReadReviewUsecase {
                 .userId(firstReview.getMember().getId())
                 .profileImageUrl(firstReview.getMember().getProfileImage())
                 .level(firstReview.getMember().getLevel())
+                .levelTitle(Level.getTitleFrom(firstReview.getMember().getLevel()))
                 .nickname(firstReview.getMember().getNickname())
                 .reviewCount(totalReviewCount)
                 .build();


### PR DESCRIPTION
## 📌 개요 (필수)

- 내 리뷰 조회 API response에 칭호 추가

<br>

## 🔨 작업 사항 (필수)

- usecase result 반환형에 levelTitle 필드를 추가하고 서비스 코드에서 enum에서 받아오는 걸로 했어요

<br>

## 💻 실행 화면 (필수)

- 칭호가 잘 들어갔다!

![image](https://github.com/user-attachments/assets/0392d480-d319-4ade-9fe1-85f169d7ef74)
