### PR TITLE
[BSVR-152] 회원 탈퇴 soft delete API

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/member/controller/MemberController.java
+++ b/application/src/main/java/org/depromeet/spot/application/member/controller/MemberController.java
@@ -109,4 +109,12 @@ public class MemberController {
 
         return MyHomeResponse.from(memberInfo);
     }
+
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Member 탈퇴 API")
+    @CurrentMember
+    public void softDelete(@Parameter(hidden = true) Long memberId) {
+        memberUsecase.softDelete(memberId);
+    }
 }

--- a/common/src/main/java/org/depromeet/spot/common/exception/member/MemberErrorCode.java
+++ b/common/src/main/java/org/depromeet/spot/common/exception/member/MemberErrorCode.java
@@ -10,6 +10,7 @@ public enum MemberErrorCode implements ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "요청 유저가 존재하지 않습니다."),
     MEMBER_NICKNAME_CONFLICT(HttpStatus.CONFLICT, "M002", "닉네임이 중복됩니다."),
     INVALID_LEVEL(HttpStatus.INTERNAL_SERVER_ERROR, "M003", "잘못된 레벨입니다."),
+    INACTIVE_MEMBER(HttpStatus.GONE, "M004", "탈퇴한 유저입니다."),
     ;
 
     private final HttpStatus status;

--- a/common/src/main/java/org/depromeet/spot/common/exception/member/MemberException.java
+++ b/common/src/main/java/org/depromeet/spot/common/exception/member/MemberException.java
@@ -29,4 +29,11 @@ public abstract class MemberException extends BusinessException {
             super(MemberErrorCode.INVALID_LEVEL);
         }
     }
+
+    public static class InactiveMemberException extends MemberException {
+
+        public InactiveMemberException() {
+            super(MemberErrorCode.INACTIVE_MEMBER);
+        }
+    }
 }

--- a/domain/src/main/java/org/depromeet/spot/domain/member/Member.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/member/Member.java
@@ -27,6 +27,7 @@ public class Member {
     private final MemberRole role;
     private final LocalDateTime createdAt;
     private final LocalDateTime deletedAt;
+    private final LocalDateTime updatedAt;
 
     public int calculateLevel(long reviewCnt) {
         if (reviewCnt <= 2) {
@@ -62,6 +63,7 @@ public class Member {
                 .role(role)
                 .createdAt(createdAt)
                 .deletedAt(deletedAt)
+                .updatedAt(updatedAt)
                 .build();
     }
 
@@ -80,6 +82,7 @@ public class Member {
                 .role(role)
                 .createdAt(createdAt)
                 .deletedAt(deletedAt)
+                .updatedAt(updatedAt)
                 .build();
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/entity/MemberEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/entity/MemberEntity.java
@@ -100,6 +100,7 @@ public class MemberEntity extends BaseEntity {
                 teamId,
                 MemberRole.valueOf(role),
                 this.getCreatedAt(),
-                this.getDeletedAt());
+                this.getDeletedAt(),
+                this.getUpdatedAt());
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberJpaRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberJpaRepository.java
@@ -37,4 +37,10 @@ public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
     @Query("update MemberEntity m set m.deletedAt = :deletedAt where m.id = :memberId")
     void updateDeletedAt(
             @Param("memberId") Long memberId, @Param("deletedAt") LocalDateTime deletedAt);
+
+    @Modifying
+    @Query(
+            "update MemberEntity m set m.deletedAt = null, m.updatedAt = :updatedAt where m.id = :memberId")
+    void updateDeletedAtAndUpdatedAt(
+            @Param("memberId") Long memberId, @Param("updatedAt") LocalDateTime updatedAt);
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberJpaRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberJpaRepository.java
@@ -1,5 +1,6 @@
 package org.depromeet.spot.jpa.member.repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.depromeet.spot.jpa.member.entity.MemberEntity;
@@ -31,4 +32,9 @@ public interface MemberJpaRepository extends JpaRepository<MemberEntity, Long> {
     void updateLevel(@Param("memberId") Long memberId, @Param("level") int level);
 
     void deleteByIdToken(String idToken);
+
+    @Modifying
+    @Query("update MemberEntity m set m.deletedAt = :deletedAt where m.id = :memberId")
+    void updateDeletedAt(
+            @Param("memberId") Long memberId, @Param("deletedAt") LocalDateTime deletedAt);
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberRepositoryImpl.java
@@ -1,5 +1,6 @@
 package org.depromeet.spot.jpa.member.repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.depromeet.spot.common.exception.member.MemberException.MemberNotFoundException;
@@ -55,5 +56,10 @@ public class MemberRepositoryImpl implements MemberRepository {
     @Override
     public void deleteByIdToken(String idToken) {
         memberJpaRepository.deleteByIdToken(idToken);
+    }
+
+    @Override
+    public void updateDeletedAt(Long memberId, LocalDateTime deletedAt) {
+        memberJpaRepository.updateDeletedAt(memberId, deletedAt);
     }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberRepositoryImpl.java
@@ -64,4 +64,9 @@ public class MemberRepositoryImpl implements MemberRepository {
     public void updateDeletedAt(Long memberId, LocalDateTime deletedAt) {
         memberJpaRepository.updateDeletedAt(memberId, deletedAt);
     }
+
+    @Override
+    public void updateDeletedAtAndUpdatedAt(Long memberId, LocalDateTime updatedAt) {
+        memberJpaRepository.updateDeletedAtAndUpdatedAt(memberId, updatedAt);
+    }
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/repository/MemberRepositoryImpl.java
@@ -1,7 +1,6 @@
 package org.depromeet.spot.jpa.member.repository;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import org.depromeet.spot.common.exception.member.MemberException.MemberNotFoundException;
 import org.depromeet.spot.domain.member.Member;
@@ -37,8 +36,11 @@ public class MemberRepositoryImpl implements MemberRepository {
     }
 
     @Override
-    public Optional<Member> findByIdToken(String idToken) {
-        return memberJpaRepository.findByIdToken(idToken).map(MemberEntity::toDomain);
+    public Member findByIdToken(String idToken) {
+        return memberJpaRepository
+                .findByIdToken(idToken)
+                .map(MemberEntity::toDomain)
+                .orElseThrow(MemberNotFoundException::new);
     }
 
     @Override

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/member/MemberUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/member/MemberUsecase.java
@@ -21,6 +21,8 @@ public interface MemberUsecase {
 
     MemberInfo findMemberInfo(Long memberId);
 
+    void softDelete(Long memberId);
+
     @Getter
     @Builder
     @AllArgsConstructor

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/member/MemberRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/member/MemberRepository.java
@@ -1,5 +1,6 @@
 package org.depromeet.spot.usecase.port.out.member;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.depromeet.spot.domain.member.Member;
@@ -19,4 +20,6 @@ public interface MemberRepository {
     Member findById(Long memberId);
 
     void deleteByIdToken(String idToken);
+
+    void updateDeletedAt(Long memberId, LocalDateTime deletedAt);
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/member/MemberRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/member/MemberRepository.java
@@ -1,7 +1,6 @@
 package org.depromeet.spot.usecase.port.out.member;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import org.depromeet.spot.domain.member.Member;
 
@@ -13,7 +12,7 @@ public interface MemberRepository {
 
     Member updateLevel(Member member);
 
-    Optional<Member> findByIdToken(String idToken);
+    Member findByIdToken(String idToken);
 
     Boolean existsByNickname(String nickname);
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/member/MemberRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/member/MemberRepository.java
@@ -21,4 +21,6 @@ public interface MemberRepository {
     void deleteByIdToken(String idToken);
 
     void updateDeletedAt(Long memberId, LocalDateTime deletedAt);
+
+    void updateDeletedAtAndUpdatedAt(Long memberId, LocalDateTime updatedAt);
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/member/MemberService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/member/MemberService.java
@@ -2,6 +2,7 @@ package org.depromeet.spot.usecase.service.member;
 
 import java.time.LocalDateTime;
 
+import org.depromeet.spot.common.exception.member.MemberException.InactiveMemberException;
 import org.depromeet.spot.common.exception.member.MemberException.MemberNicknameConflictException;
 import org.depromeet.spot.domain.member.Member;
 import org.depromeet.spot.domain.team.BaseballTeam;
@@ -46,9 +47,7 @@ public class MemberService implements MemberUsecase {
 
         // 회원 탈퇴 유저일 경우 재가입
         if (existedMember.getDeletedAt() != null) {
-            memberRepository.updateDeletedAtAndUpdatedAt(
-                    existedMember.getId(), LocalDateTime.now());
-            return memberRepository.findByIdToken(existedMember.getIdToken());
+            throw new InactiveMemberException();
         }
         return existedMember;
     }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/member/MemberService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/member/MemberService.java
@@ -1,5 +1,6 @@
 package org.depromeet.spot.usecase.service.member;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.depromeet.spot.common.exception.member.MemberException.MemberNicknameConflictException;
@@ -88,5 +89,10 @@ public class MemberService implements MemberUsecase {
         BaseballTeam baseballTeam = readBaseballTeamUsecase.findById(member.getTeamId());
 
         return MemberInfo.of(member, baseballTeam);
+    }
+
+    @Override
+    public void softDelete(Long memberId) {
+        memberRepository.updateDeletedAt(memberId, LocalDateTime.now());
     }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/member/MemberService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/member/MemberService.java
@@ -1,10 +1,8 @@
 package org.depromeet.spot.usecase.service.member;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import org.depromeet.spot.common.exception.member.MemberException.MemberNicknameConflictException;
-import org.depromeet.spot.common.exception.member.MemberException.MemberNotFoundException;
 import org.depromeet.spot.domain.member.Member;
 import org.depromeet.spot.domain.team.BaseballTeam;
 import org.depromeet.spot.usecase.port.in.member.MemberUsecase;
@@ -36,9 +34,9 @@ public class MemberService implements MemberUsecase {
             throw new MemberNicknameConflictException();
         }
         Member memberResult = oauthRepository.getRegisterUserInfo(accessToken, member);
-        Optional<Member> existedMember = memberRepository.findByIdToken(memberResult.getIdToken());
-        if (existedMember.isPresent()) {
-            return existedMember.get();
+        Member existedMember = memberRepository.findByIdToken(memberResult.getIdToken());
+        if (existedMember != null) {
+            return existedMember;
         }
 
         return memberRepository.save(memberResult);
@@ -47,13 +45,8 @@ public class MemberService implements MemberUsecase {
     @Override
     public Member login(String accessToken) {
         Member memberResult = oauthRepository.getLoginUserInfo(accessToken);
-        Optional<Member> existedMember = memberRepository.findByIdToken(memberResult.getIdToken());
-        if (existedMember.isEmpty()) {
-            // TODO : 404 말고 사용되지 않는 Exception 코드가 필요함.
-            //            throw new MemberNotFoundException();
-            return null;
-        }
-        return existedMember.get();
+        Member existedMember = memberRepository.findByIdToken(memberResult.getIdToken());
+        return existedMember;
     }
 
     @Override
@@ -72,12 +65,8 @@ public class MemberService implements MemberUsecase {
     @Override
     public Boolean deleteMember(String accessToken) {
         Member memberResult = oauthRepository.getLoginUserInfo(accessToken);
-        Optional<Member> existedMember = memberRepository.findByIdToken(memberResult.getIdToken());
+        memberRepository.findByIdToken(memberResult.getIdToken());
 
-        // 멤버 없으면 오류 출력
-        if (existedMember.isEmpty()) {
-            throw new MemberNotFoundException();
-        }
         memberRepository.deleteByIdToken(memberResult.getIdToken());
         return Boolean.TRUE;
     }


### PR DESCRIPTION
## 📌 개요 (필수)

- 회원 탈퇴 soft delete 구현

<br>

## 🔨 작업 사항 (필수)

- 회원 탈퇴 soft delete API 추가
- 회원 탈퇴 유저 로그인 시 재가입 처리
  - 

<br>

## 💻 실행 화면 (필수)

- 성공
![image](https://github.com/user-attachments/assets/ce8b4902-d15b-4d8d-b2c0-b9b43128fa23)
![image](https://github.com/user-attachments/assets/30d6f08c-4444-4625-bfd9-ebb0b0fc24b9)

- 삭제 후 로그인 (재가입 처리)
![image](https://github.com/user-attachments/assets/6ebe7858-9d8c-4ce6-b84f-73fdea013f77)

