### PR TITLE
[BSVR-162] 블록별 리뷰 조회 Location 정보 최상단으로 응답 구조 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -387,3 +387,4 @@ gradle-app.setting
 *.application-jwt.yml
 application-jwt.yml
 application-kakao.yml
+application-sentry.yml

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/BlockReviewListResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/BlockReviewListResponse.java
@@ -6,8 +6,10 @@ import java.util.stream.Collectors;
 import org.depromeet.spot.domain.review.image.TopReviewImage;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.BlockKeywordInfo;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.BlockReviewListResult;
+import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.LocationInfo;
 
 public record BlockReviewListResponse(
+        LocationInfo location,
         List<KeywordCountResponse> keywords,
         List<BaseReviewResponse> reviews,
         List<TopReviewImageResponse> topReviewImages,
@@ -25,6 +27,7 @@ public record BlockReviewListResponse(
             Integer seatNumber,
             Integer year,
             Integer month) {
+
         List<BaseReviewResponse> reviewResponses =
                 result.reviews().stream()
                         .map(BaseReviewResponse::from)
@@ -46,6 +49,7 @@ public record BlockReviewListResponse(
         boolean last = result.number() == result.totalPages() - 1;
 
         return new BlockReviewListResponse(
+                result.location(),
                 keywordResponses,
                 reviewResponses,
                 topReviewImageResponses,

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewJpaRepository.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewJpaRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.depromeet.spot.domain.review.ReviewYearMonth;
 import org.depromeet.spot.jpa.review.entity.ReviewEntity;
+import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.LocationInfo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -57,4 +58,14 @@ public interface ReviewJpaRepository extends JpaRepository<ReviewEntity, Long> {
             @Param("reviewId") Long reviewId,
             @Param("memberId") Long memberId,
             @Param("deletedAt") LocalDateTime deletedAt);
+
+    @Query(
+            "SELECT new org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase$LocationInfo("
+                    + "s.name, sec.name, b.code) "
+                    + "FROM StadiumEntity s "
+                    + "JOIN BlockEntity b ON b.stadiumId = s.id "
+                    + "JOIN SectionEntity sec ON sec.id = b.sectionId "
+                    + "WHERE s.id = :stadiumId AND b.code = :blockCode")
+    LocationInfo findLocationInfoByStadiumIdAndBlockCode(
+            @Param("stadiumId") Long stadiumId, @Param("blockCode") String blockCode);
 }

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewRepositoryImpl.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/review/repository/ReviewRepositoryImpl.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.depromeet.spot.domain.review.Review;
 import org.depromeet.spot.domain.review.ReviewYearMonth;
 import org.depromeet.spot.jpa.review.entity.ReviewEntity;
+import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.LocationInfo;
 import org.depromeet.spot.usecase.port.out.review.ReviewRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -75,5 +76,10 @@ public class ReviewRepositoryImpl implements ReviewRepository {
             throw new IllegalArgumentException("Review not found or not owned by the member");
         }
         return reviewId;
+    }
+
+    @Override
+    public LocationInfo findLocationInfoByStadiumIdAndBlockCode(Long stadiumId, String blockCode) {
+        return reviewJpaRepository.findLocationInfoByStadiumIdAndBlockCode(stadiumId, blockCode);
     }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
@@ -27,6 +27,7 @@ public interface ReadReviewUsecase {
 
     @Builder
     record BlockReviewListResult(
+            LocationInfo location,
             List<Review> reviews,
             List<BlockKeywordInfo> topKeywords,
             List<TopReviewImage> topReviewImages,
@@ -37,6 +38,9 @@ public interface ReadReviewUsecase {
 
     @Builder
     record BlockKeywordInfo(String content, Long count, Boolean isPositive) {}
+
+    @Builder
+    record LocationInfo(String stadiumName, String sectionName, String blockCode) {}
 
     @Builder
     record MyReviewListResult(

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.depromeet.spot.domain.review.Review;
 import org.depromeet.spot.domain.review.ReviewYearMonth;
+import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.LocationInfo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -29,4 +30,6 @@ public interface ReviewRepository {
     List<ReviewYearMonth> findReviewMonthsByMemberId(Long memberId);
 
     Long softDeleteByIdAndMemberId(Long reviewId, Long memberId);
+
+    LocationInfo findLocationInfoByStadiumIdAndBlockCode(Long stadiumId, String blockCode);
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -44,6 +44,10 @@ public class ReadReviewService implements ReadReviewUsecase {
             Integer month,
             Pageable pageable) {
 
+        // LocationInfo 조회
+        LocationInfo locationInfo =
+                reviewRepository.findLocationInfoByStadiumIdAndBlockCode(stadiumId, blockCode);
+
         // stadiumId랑 blockCode로 blockId를 조회 후 이걸 통해 reviews를 조회
         Page<Review> reviewPage =
                 reviewRepository.findByStadiumIdAndBlockCode(
@@ -62,6 +66,7 @@ public class ReadReviewService implements ReadReviewUsecase {
         List<Review> reviewsWithKeywords = mapKeywordsToReviews(reviewPage.getContent());
 
         return BlockReviewListResult.builder()
+                .location(locationInfo)
                 .reviews(reviewsWithKeywords)
                 .topKeywords(topKeywords)
                 .topReviewImages(topReviewImages)


### PR DESCRIPTION
## 📌 개요 (필수)

- 블록별 리뷰 조회 Location 정보 최상단으로 응답 구조 변경

<br>

## 🔨 작업 사항 (필수)

**문제점**
- 리뷰가 비어있으면 아래 화면의 정보를 받지 못한다.

![image](https://github.com/user-attachments/assets/79589dfb-dc61-4e68-81fe-3cf7d4ce61a4)


**해결**
- 별도의 쿼리로 stadiumId와 blockCode를 활용해 location 정보를 따로 받아온다.

<br>

## 💻 실행 화면 (필수)

- location으로 잘 들어갔다! 이제 review가 비어있어도 블록에 대한 응답은 받을 수 있다.

![image](https://github.com/user-attachments/assets/20393791-6e03-4c55-8283-9f7614b5e6e7)

