### PR TITLE
[BSVR-169] 리뷰 생성 API req validation 업데이트: 키워드 개수 조건, 날짜 포맷

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/review/CreateReviewController.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/CreateReviewController.java
@@ -37,7 +37,7 @@ public class CreateReviewController {
             @PathVariable @Positive @NotNull final Long blockId,
             @PathVariable @Positive @NotNull final Integer seatNumber,
             @Parameter(hidden = true) Long memberId,
-            @RequestBody @Valid @NotNull CreateReviewRequest request) {
+            @RequestBody @Valid CreateReviewRequest request) {
         CreateReviewUsecase.CreateReviewResult result =
                 createReviewUsecase.create(blockId, seatNumber, memberId, request.toCommand());
         return BaseReviewResponse.from(result.review());

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/request/CreateReviewRequest.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/request/CreateReviewRequest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import jakarta.validation.constraints.NotNull;
 
 import org.depromeet.spot.common.exception.review.ReviewException.InvalidReviewDateTimeFormatException;
+import org.depromeet.spot.common.exception.review.ReviewException.InvalidReviewKeywordsException;
 import org.depromeet.spot.usecase.port.in.review.CreateReviewUsecase.CreateReviewCommand;
 
 public record CreateReviewRequest(
@@ -30,7 +31,7 @@ public record CreateReviewRequest(
 
     private void validateGoodAndBad() {
         if ((good == null || good.isEmpty()) && (bad == null || bad.isEmpty())) {
-            throw new IllegalArgumentException("At least one of 'good' or 'bad' must be provided");
+            throw new InvalidReviewKeywordsException();
         }
     }
 

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/request/CreateReviewRequest.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/request/CreateReviewRequest.java
@@ -7,13 +7,20 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 
+import jakarta.validation.constraints.NotNull;
+
 import org.depromeet.spot.common.exception.review.ReviewException.InvalidReviewDateTimeFormatException;
 import org.depromeet.spot.usecase.port.in.review.CreateReviewUsecase.CreateReviewCommand;
 
 public record CreateReviewRequest(
-        List<String> images, List<String> good, List<String> bad, String content, String dateTime) {
+        @NotNull List<String> images,
+        List<String> good,
+        List<String> bad,
+        @NotNull String content,
+        @NotNull String dateTime) {
 
     public CreateReviewCommand toCommand() {
+        validateGoodAndBad();
         return CreateReviewCommand.builder()
                 .images(images)
                 .good(good)
@@ -21,6 +28,12 @@ public record CreateReviewRequest(
                 .content(content)
                 .dateTime(toLocalDateTime(dateTime))
                 .build();
+    }
+
+    private void validateGoodAndBad() {
+        if ((good == null || good.isEmpty()) && (bad == null || bad.isEmpty())) {
+            throw new IllegalArgumentException("At least one of 'good' or 'bad' must be provided");
+        }
     }
 
     private LocalDateTime toLocalDateTime(String dateStr) {

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/request/CreateReviewRequest.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/request/CreateReviewRequest.java
@@ -14,7 +14,7 @@ public record CreateReviewRequest(
         @NotNull List<String> images,
         List<String> good,
         List<String> bad,
-        @NotNull String content,
+        String content,
         @NotNull String dateTime) {
 
     public CreateReviewCommand toCommand() {

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/request/CreateReviewRequest.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/request/CreateReviewRequest.java
@@ -1,8 +1,6 @@
 package org.depromeet.spot.application.review.dto.request;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
@@ -36,12 +34,10 @@ public record CreateReviewRequest(
         }
     }
 
-    private LocalDateTime toLocalDateTime(String dateStr) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy.MM.dd");
+    private LocalDateTime toLocalDateTime(String dateTimeStr) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
         try {
-            LocalDate date = LocalDate.parse(dateStr, formatter);
-            // 시간 정보가 없으므로 자정(00:00)으로 설정
-            return LocalDateTime.of(date, LocalTime.MIDNIGHT);
+            return LocalDateTime.parse(dateTimeStr, formatter);
         } catch (DateTimeParseException e) {
             throw new InvalidReviewDateTimeFormatException();
         }

--- a/common/src/main/java/org/depromeet/spot/common/exception/review/ReviewErrorCode.java
+++ b/common/src/main/java/org/depromeet/spot/common/exception/review/ReviewErrorCode.java
@@ -10,7 +10,9 @@ public enum ReviewErrorCode implements ErrorCode {
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "RV001", "요청한 리뷰를 찾을 수 없습니다."),
     INVALID_REVIEW_DATA(HttpStatus.BAD_REQUEST, "RV002", "유효하지 않은 리뷰 데이터입니다."),
     INVALID_REVIEW_DATETIME_FORMAT(
-            HttpStatus.BAD_REQUEST, "RV003", "리뷰 작성일시는 yyyy-MM-dd HH:mm 포맷이어야 합니다.");
+            HttpStatus.BAD_REQUEST, "RV003", "리뷰 작성일시는 yyyy-MM-dd HH:mm 포맷이어야 합니다."),
+    INVALID_REVIEW_KEYWORDS(
+            HttpStatus.BAD_REQUEST, "RV004", "리뷰의 'good' 또는 'bad' 중 적어도 하나는 제공되어야 합니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/common/src/main/java/org/depromeet/spot/common/exception/review/ReviewException.java
+++ b/common/src/main/java/org/depromeet/spot/common/exception/review/ReviewException.java
@@ -36,4 +36,14 @@ public abstract class ReviewException extends BusinessException {
             super(ReviewErrorCode.INVALID_REVIEW_DATETIME_FORMAT.appended(str));
         }
     }
+
+    public static class InvalidReviewKeywordsException extends ReviewException {
+        public InvalidReviewKeywordsException() {
+            super(ReviewErrorCode.INVALID_REVIEW_KEYWORDS);
+        }
+
+        public InvalidReviewKeywordsException(String str) {
+            super(ReviewErrorCode.INVALID_REVIEW_KEYWORDS.appended(str));
+        }
+    }
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- 리뷰 생성 API에서 request 필드들에 대한 제약 조건을 업데이트했어요.

<br>

## 🔨 작업 사항 (필수)

### 변경사항 1️⃣: 키워드 nullable하게 변경 후 개수 검증 추가
**`기존`**
- @NotNull List<String> good, @NotNull List<String> bad
**`변경`**
- @NotNull 어노테이션 삭제 및 키워드가 둘 다 비어있으면 RV004 custom exception(아래 사진에 나와있음)을 반환하는 validateGoodAndBad 메서드 구현 및 적용

### 변경사항 2️⃣: dateTime 날짜 포맷
**`기존`**
- yy.mm.dd
**`변경`**
- yyyy-mm-dd HH:mm

### 변경사항 3️⃣: content 필드 nullable 하게 변경
**`기존`**
- @NotNull String content
**`변경`**
- String content

<br>

## 💻 실행 화면 (필수)

- keyword가 하나만 들어와도 잘 저장되고, 조회도 잘된다.

<img width="1295" alt="image" src="https://github.com/user-attachments/assets/674f94c3-98d0-4a90-892e-483557c1cff1">

- keyword가 둘 다 비어있는 째로 들어온다면 아래와 같이 custom exception을 반환한다.

<img width="1303" alt="image" src="https://github.com/user-attachments/assets/78a74f98-c61e-4b4a-962b-b1126a33ea94">

