### PR TITLE
[BSVR-173] 리뷰 pk로 특정 리뷰 조회 API 구현

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/review/ReadReviewController.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/ReadReviewController.java
@@ -3,7 +3,6 @@ package org.depromeet.spot.application.review;
 import java.util.List;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
@@ -121,7 +120,7 @@ public class ReadReviewController {
     @Operation(summary = "리뷰 id(pk)로 특정 리뷰를 조회한다.")
     public BaseReviewResponse findReviewByReviewId(
             @Parameter(hidden = true) Long memberId,
-            @PathVariable("reviewId") @NotBlank @Parameter(description = "리뷰 PK", required = true)
+            @PathVariable("reviewId") @NotNull @Parameter(description = "리뷰 PK", required = true)
                     Long reviewId) {
         ReadReviewUsecase.ReviewResult reviewResult = readReviewUsecase.findReviewById(reviewId);
         return BaseReviewResponse.from(reviewResult.review());

--- a/application/src/main/java/org/depromeet/spot/application/review/ReadReviewController.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/ReadReviewController.java
@@ -3,12 +3,14 @@ package org.depromeet.spot.application.review;
 import java.util.List;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 import org.depromeet.spot.application.common.annotation.CurrentMember;
 import org.depromeet.spot.application.review.dto.request.BlockReviewRequest;
 import org.depromeet.spot.application.review.dto.request.MyReviewRequest;
+import org.depromeet.spot.application.review.dto.response.BaseReviewResponse;
 import org.depromeet.spot.application.review.dto.response.BlockReviewListResponse;
 import org.depromeet.spot.application.review.dto.response.MyRecentReviewResponse;
 import org.depromeet.spot.application.review.dto.response.MyReviewListResponse;
@@ -111,5 +113,17 @@ public class ReadReviewController {
         ReadReviewUsecase.MyRecentReviewResult result =
                 readReviewUsecase.findLastReviewByMemberId(memberId);
         return MyRecentReviewResponse.from(result);
+    }
+
+    @CurrentMember
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/reviews/{reviewId}")
+    @Operation(summary = "리뷰 id(pk)로 특정 리뷰를 조회한다.")
+    public BaseReviewResponse findReviewByReviewId(
+            @Parameter(hidden = true) Long memberId,
+            @PathVariable("reviewId") @NotBlank @Parameter(description = "리뷰 PK", required = true)
+                    Long reviewId) {
+        ReadReviewUsecase.ReviewResult reviewResult = readReviewUsecase.findReviewById(reviewId);
+        return BaseReviewResponse.from(reviewResult.review());
     }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
@@ -27,6 +27,8 @@ public interface ReadReviewUsecase {
 
     MyRecentReviewResult findLastReviewByMemberId(Long memberId);
 
+    ReviewResult findReviewById(Long reviewId);
+
     @Builder
     record BlockReviewListResult(
             LocationInfo location,
@@ -64,4 +66,7 @@ public interface ReadReviewUsecase {
 
     @Builder
     record MyRecentReviewResult(Review review, Long reviewCount) {}
+
+    @Builder
+    record ReviewResult(Review review) {}
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -193,58 +193,6 @@ public class ReadReviewService implements ReadReviewUsecase {
         return reviews.stream().map(this::mapKeywordsToSingleReview).collect(Collectors.toList());
     }
 
-    //    private List<Review> mapKeywordsToReviews(List<Review> reviews) {
-    //        List<Long> keywordIds =
-    //                reviews.stream()
-    //                        .flatMap(review -> review.getKeywords().stream())
-    //                        .map(ReviewKeyword::getKeywordId)
-    //                        .distinct()
-    //                        .collect(Collectors.toList());
-    //
-    //        Map<Long, Keyword> keywordMap = keywordRepository.findByIds(keywordIds);
-    //
-    //        return reviews.stream()
-    //                .map(
-    //                        review -> {
-    //                            List<ReviewKeyword> mappedKeywords =
-    //                                    review.getKeywords().stream()
-    //                                            .map(
-    //                                                    reviewKeyword -> {
-    //                                                        Keyword keyword =
-    //                                                                keywordMap.get(
-    //                                                                        reviewKeyword
-    //
-    // .getKeywordId());
-    //                                                        return ReviewKeyword.create(
-    //                                                                reviewKeyword.getId(),
-    //                                                                keyword.getId());
-    //                                                    })
-    //                                            .collect(Collectors.toList());
-    //
-    //                            Review mappedReview =
-    //                                    Review.builder()
-    //                                            .id(review.getId())
-    //                                            .member(review.getMember())
-    //                                            .stadium(review.getStadium())
-    //                                            .section(review.getSection())
-    //                                            .block(review.getBlock())
-    //                                            .row(review.getRow())
-    //                                            .seat(review.getSeat())
-    //                                            .dateTime(review.getDateTime())
-    //                                            .content(review.getContent())
-    //                                            .deletedAt(review.getDeletedAt())
-    //                                            .images(review.getImages())
-    //                                            .keywords(mappedKeywords)
-    //                                            .build();
-    //
-    //                            // Keyword 정보를 Review 객체에 추가
-    //                            mappedReview.setKeywordMap(keywordMap);
-    //
-    //                            return mappedReview;
-    //                        })
-    //                .collect(Collectors.toList());
-    //    }
-
     private Review mapKeywordsToReview(Review review) {
         // TODO : (민성) 중복되는 Keywords 로직 처리 부분 메소드로 분리하기!
         List<Long> keywordIds =

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.depromeet.spot.common.exception.review.ReviewException.ReviewNotFoundException;
 import org.depromeet.spot.domain.member.Member;
 import org.depromeet.spot.domain.member.enums.Level;
 import org.depromeet.spot.domain.review.Review;
@@ -108,16 +109,18 @@ public class ReadReviewService implements ReadReviewUsecase {
         return reviewRepository.findReviewMonthsByMemberId(memberId);
     }
 
-    private MemberInfoOnMyReviewResult createMemberInfoFromMember(
-            Member member, long totalReviewCount) {
-        return MemberInfoOnMyReviewResult.builder()
-                .userId(member.getId())
-                .profileImageUrl(member.getProfileImage())
-                .level(member.getLevel())
-                .levelTitle(Level.getTitleFrom(member.getLevel()))
-                .nickname(member.getNickname())
-                .reviewCount(totalReviewCount)
-                .build();
+    @Override
+    public ReviewResult findReviewById(Long reviewId) {
+        Review review =
+                reviewRepository
+                        .findById(reviewId)
+                        .orElseThrow(
+                                () ->
+                                        new ReviewNotFoundException(
+                                                "Review not found with id: " + reviewId));
+        Review reviewWithKeywords = mapKeywordsToSingleReview(review);
+
+        return ReviewResult.builder().review(reviewWithKeywords).build();
     }
 
     @Override
@@ -134,56 +137,113 @@ public class ReadReviewService implements ReadReviewUsecase {
                 .build();
     }
 
-    private List<Review> mapKeywordsToReviews(List<Review> reviews) {
+    private MemberInfoOnMyReviewResult createMemberInfoFromMember(
+            Member member, long totalReviewCount) {
+        return MemberInfoOnMyReviewResult.builder()
+                .userId(member.getId())
+                .profileImageUrl(member.getProfileImage())
+                .level(member.getLevel())
+                .levelTitle(Level.getTitleFrom(member.getLevel()))
+                .nickname(member.getNickname())
+                .reviewCount(totalReviewCount)
+                .build();
+    }
+
+    private Review mapKeywordsToSingleReview(Review review) {
         List<Long> keywordIds =
-                reviews.stream()
-                        .flatMap(review -> review.getKeywords().stream())
+                review.getKeywords().stream()
                         .map(ReviewKeyword::getKeywordId)
                         .distinct()
                         .collect(Collectors.toList());
 
         Map<Long, Keyword> keywordMap = keywordRepository.findByIds(keywordIds);
 
-        return reviews.stream()
-                .map(
-                        review -> {
-                            List<ReviewKeyword> mappedKeywords =
-                                    review.getKeywords().stream()
-                                            .map(
-                                                    reviewKeyword -> {
-                                                        Keyword keyword =
-                                                                keywordMap.get(
-                                                                        reviewKeyword
-                                                                                .getKeywordId());
-                                                        return ReviewKeyword.create(
-                                                                reviewKeyword.getId(),
-                                                                keyword.getId());
-                                                    })
-                                            .collect(Collectors.toList());
+        List<ReviewKeyword> mappedKeywords =
+                review.getKeywords().stream()
+                        .map(
+                                reviewKeyword -> {
+                                    Keyword keyword = keywordMap.get(reviewKeyword.getKeywordId());
+                                    return ReviewKeyword.create(
+                                            reviewKeyword.getId(), keyword.getId());
+                                })
+                        .collect(Collectors.toList());
 
-                            Review mappedReview =
-                                    Review.builder()
-                                            .id(review.getId())
-                                            .member(review.getMember())
-                                            .stadium(review.getStadium())
-                                            .section(review.getSection())
-                                            .block(review.getBlock())
-                                            .row(review.getRow())
-                                            .seat(review.getSeat())
-                                            .dateTime(review.getDateTime())
-                                            .content(review.getContent())
-                                            .deletedAt(review.getDeletedAt())
-                                            .images(review.getImages())
-                                            .keywords(mappedKeywords)
-                                            .build();
+        Review mappedReview =
+                Review.builder()
+                        .id(review.getId())
+                        .member(review.getMember())
+                        .stadium(review.getStadium())
+                        .section(review.getSection())
+                        .block(review.getBlock())
+                        .row(review.getRow())
+                        .seat(review.getSeat())
+                        .dateTime(review.getDateTime())
+                        .content(review.getContent())
+                        .deletedAt(review.getDeletedAt())
+                        .images(review.getImages())
+                        .keywords(mappedKeywords)
+                        .build();
 
-                            // Keyword 정보를 Review 객체에 추가
-                            mappedReview.setKeywordMap(keywordMap);
+        mappedReview.setKeywordMap(keywordMap);
 
-                            return mappedReview;
-                        })
-                .collect(Collectors.toList());
+        return mappedReview;
     }
+
+    private List<Review> mapKeywordsToReviews(List<Review> reviews) {
+        return reviews.stream().map(this::mapKeywordsToSingleReview).collect(Collectors.toList());
+    }
+
+    //    private List<Review> mapKeywordsToReviews(List<Review> reviews) {
+    //        List<Long> keywordIds =
+    //                reviews.stream()
+    //                        .flatMap(review -> review.getKeywords().stream())
+    //                        .map(ReviewKeyword::getKeywordId)
+    //                        .distinct()
+    //                        .collect(Collectors.toList());
+    //
+    //        Map<Long, Keyword> keywordMap = keywordRepository.findByIds(keywordIds);
+    //
+    //        return reviews.stream()
+    //                .map(
+    //                        review -> {
+    //                            List<ReviewKeyword> mappedKeywords =
+    //                                    review.getKeywords().stream()
+    //                                            .map(
+    //                                                    reviewKeyword -> {
+    //                                                        Keyword keyword =
+    //                                                                keywordMap.get(
+    //                                                                        reviewKeyword
+    //
+    // .getKeywordId());
+    //                                                        return ReviewKeyword.create(
+    //                                                                reviewKeyword.getId(),
+    //                                                                keyword.getId());
+    //                                                    })
+    //                                            .collect(Collectors.toList());
+    //
+    //                            Review mappedReview =
+    //                                    Review.builder()
+    //                                            .id(review.getId())
+    //                                            .member(review.getMember())
+    //                                            .stadium(review.getStadium())
+    //                                            .section(review.getSection())
+    //                                            .block(review.getBlock())
+    //                                            .row(review.getRow())
+    //                                            .seat(review.getSeat())
+    //                                            .dateTime(review.getDateTime())
+    //                                            .content(review.getContent())
+    //                                            .deletedAt(review.getDeletedAt())
+    //                                            .images(review.getImages())
+    //                                            .keywords(mappedKeywords)
+    //                                            .build();
+    //
+    //                            // Keyword 정보를 Review 객체에 추가
+    //                            mappedReview.setKeywordMap(keywordMap);
+    //
+    //                            return mappedReview;
+    //                        })
+    //                .collect(Collectors.toList());
+    //    }
 
     private Review mapKeywordsToReview(Review review) {
         // TODO : (민성) 중복되는 Keywords 로직 처리 부분 메소드로 분리하기!


### PR DESCRIPTION
## 📌 개요 (필수)

- GUI 업데이트 되면서 추가된 리뷰 pk로 특정 리뷰를 조회해오는 api를 구현했어요. 
- [API 명세서](https://www.notion.so/depromeet/NEW-018781796c6345af8de5205becd0c3ee?pvs=4)

<br>

## 🔨 작업 사항 (필수)

- 이미 repository에 findById 함수가 구현이 되어있어서 service 함수와 controller만 만들어줬어요.
- 서비스 함수에서 리뷰객체와 키워드 객체를 매핑하는 코드가 많이 겹쳐서 리팩토링을 수행했어요.

<br>

## 💻 실행 화면 (필수)

- 잘된다!, service에서 리뷰 객체와 키워드 객체를 매핑하는 함수를 리팩토링해서 다른 조회 API도 postman에서 잘 작동하는 것을 확인!

![image](https://github.com/user-attachments/assets/1a51980c-5453-4507-a588-1ddd7f45678e)

