### PR TITLE
[BSVR-168] 홈 팀 label 폰트 색상 추가

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/HomeTeamInfoResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/HomeTeamInfoResponse.java
@@ -2,12 +2,14 @@ package org.depromeet.spot.application.stadium.dto.response;
 
 import org.depromeet.spot.usecase.port.in.team.ReadStadiumHomeTeamUsecase.HomeTeamInfo;
 
-public record HomeTeamInfoResponse(Long id, String alias, String color) {
+public record HomeTeamInfoResponse(
+        Long id, String alias, String backgroundColor, String fontColor) {
 
     public static HomeTeamInfoResponse from(HomeTeamInfo homeTeamInfo) {
         return new HomeTeamInfoResponse(
                 homeTeamInfo.getId(),
                 homeTeamInfo.getAlias(),
-                homeTeamInfo.getLabelBackgroundColor());
+                homeTeamInfo.getLabelBackgroundColor(),
+                homeTeamInfo.getLabelFontColor());
     }
 }

--- a/domain/src/main/java/org/depromeet/spot/domain/team/BaseballTeam.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/team/BaseballTeam.java
@@ -17,12 +17,18 @@ public class BaseballTeam {
     private final String alias;
     private final String logo;
     private final HexCode labelBackgroundColor;
+    private final HexCode labelFontColor;
 
     private static final int MAX_NAME_LENGTH = 20;
     private static final int MAX_ALIAS_LENGTH = 10;
 
     public BaseballTeam(
-            Long id, String name, String alias, String logo, HexCode labelBackgroundColor) {
+            Long id,
+            String name,
+            String alias,
+            String logo,
+            HexCode labelBackgroundColor,
+            HexCode labelFontColor) {
         checkValidName(name);
         checkValidAlias(alias);
         checkValidLogo(logo);
@@ -32,6 +38,7 @@ public class BaseballTeam {
         this.alias = alias;
         this.logo = logo;
         this.labelBackgroundColor = labelBackgroundColor;
+        this.labelFontColor = labelFontColor;
     }
 
     private void checkValidName(final String name) {

--- a/domain/src/test/java/org/depromeet/spot/domain/team/BaseballTeamTest.java
+++ b/domain/src/test/java/org/depromeet/spot/domain/team/BaseballTeamTest.java
@@ -18,6 +18,7 @@ class BaseballTeamTest {
     void name이_null_또는_blank일_때_BaseballTeam을_생성할_수_없다(String name) {
         // given
         HexCode backgroundColor = new HexCode("#FFFFFF");
+        HexCode fontColor = new HexCode("#FFFFFF");
 
         // when
         // then
@@ -26,7 +27,12 @@ class BaseballTeamTest {
                         assertThatThrownBy(
                                         () ->
                                                 new BaseballTeam(
-                                                        1L, name, "alias", "logo", backgroundColor))
+                                                        1L,
+                                                        name,
+                                                        "alias",
+                                                        "logo",
+                                                        backgroundColor,
+                                                        fontColor))
                                 .isInstanceOf(InvalidBaseballTeamNameException.class),
                 () ->
                         assertThatThrownBy(
@@ -43,11 +49,15 @@ class BaseballTeamTest {
     void name_길이는_20글자를_초과할_수_없다() {
         // given
         HexCode backgroundColor = new HexCode("#FFFFFF");
+        HexCode fontColor = new HexCode("#FFFFFF");
         final String name = "012345678901234567890";
 
         // when
         // then
-        assertThatThrownBy(() -> new BaseballTeam(1L, name, "alias", "logo", backgroundColor))
+        assertThatThrownBy(
+                        () ->
+                                new BaseballTeam(
+                                        1L, name, "alias", "logo", backgroundColor, fontColor))
                 .isInstanceOf(InvalidBaseballTeamNameException.class);
     }
 
@@ -56,6 +66,7 @@ class BaseballTeamTest {
     void alias가_null_또는_blank일_때_BaseballTeam을_생성할_수_없다(String alias) {
         // given
         HexCode backgroundColor = new HexCode("#FFFFFF");
+        HexCode fontColor = new HexCode("#FFFFFF");
 
         // when
         // then
@@ -64,7 +75,12 @@ class BaseballTeamTest {
                         assertThatThrownBy(
                                         () ->
                                                 new BaseballTeam(
-                                                        1L, "name", alias, "logo", backgroundColor))
+                                                        1L,
+                                                        "name",
+                                                        alias,
+                                                        "logo",
+                                                        backgroundColor,
+                                                        fontColor))
                                 .isInstanceOf(InvalidBaseballAliasNameException.class),
                 () ->
                         assertThatThrownBy(
@@ -81,11 +97,15 @@ class BaseballTeamTest {
     void alias_길이는_10글자를_초과할_수_없다() {
         // given
         HexCode backgroundColor = new HexCode("#FFFFFF");
+        HexCode fontColor = new HexCode("#FFFFFF");
         final String alias = "01234567890";
 
         // when
         // then
-        assertThatThrownBy(() -> new BaseballTeam(1L, "name", alias, "logo", backgroundColor))
+        assertThatThrownBy(
+                        () ->
+                                new BaseballTeam(
+                                        1L, "name", alias, "logo", backgroundColor, fontColor))
                 .isInstanceOf(InvalidBaseballAliasNameException.class);
     }
 
@@ -94,6 +114,7 @@ class BaseballTeamTest {
     void logo가_null_또는_blank일_때_BaseballTeam을_생성할_수_없다(String logo) {
         // given
         HexCode backgroundColor = new HexCode("#FFFFFF");
+        HexCode fontColor = new HexCode("#FFFFFF");
 
         // when
         // then
@@ -102,7 +123,12 @@ class BaseballTeamTest {
                         assertThatThrownBy(
                                         () ->
                                                 new BaseballTeam(
-                                                        1L, "name", "alias", logo, backgroundColor))
+                                                        1L,
+                                                        "name",
+                                                        "alias",
+                                                        logo,
+                                                        backgroundColor,
+                                                        fontColor))
                                 .isInstanceOf(EmptyTeamLogoException.class),
                 () ->
                         assertThatThrownBy(

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/team/entity/BaseballTeamEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/team/entity/BaseballTeamEntity.java
@@ -29,16 +29,21 @@ public class BaseballTeamEntity extends BaseEntity {
     @Column(name = "label_background_color", nullable = false, unique = true, length = 10)
     private String labelBackgroundColor;
 
+    @Column(name = "label_font_color", nullable = false, length = 10)
+    private String labelFontColor;
+
     public static BaseballTeamEntity from(BaseballTeam baseballTeam) {
         return new BaseballTeamEntity(
                 baseballTeam.getName(),
                 baseballTeam.getAlias(),
                 baseballTeam.getLogo(),
-                baseballTeam.getLabelBackgroundColor().getValue());
+                baseballTeam.getLabelBackgroundColor().getValue(),
+                baseballTeam.getLabelFontColor().getValue());
     }
 
     public BaseballTeam toDomain() {
         HexCode backgroundColor = new HexCode(labelBackgroundColor);
-        return new BaseballTeam(this.getId(), name, alias, logo, backgroundColor);
+        HexCode fontColor = new HexCode(labelFontColor);
+        return new BaseballTeam(this.getId(), name, alias, logo, backgroundColor, fontColor);
     }
 }

--- a/infrastructure/jpa/src/main/resources/application-jpa.yaml
+++ b/infrastructure/jpa/src/main/resources/application-jpa.yaml
@@ -2,7 +2,7 @@ spring:
     datasource:
         url: jdbc:mysql://localhost:3306/spot
         username: test1234
-        password: test1234
+        password: DPM15thspot!
         driver-class-name: com.mysql.cj.jdbc.Driver
 
     jpa:

--- a/infrastructure/jpa/src/main/resources/application-jpa.yaml
+++ b/infrastructure/jpa/src/main/resources/application-jpa.yaml
@@ -2,7 +2,7 @@ spring:
     datasource:
         url: jdbc:mysql://localhost:3306/spot
         username: test1234
-        password: DPM15thspot!
+        password: test1234
         driver-class-name: com.mysql.cj.jdbc.Driver
 
     jpa:

--- a/infrastructure/jpa/src/main/resources/data.sql
+++ b/infrastructure/jpa/src/main/resources/data.sql
@@ -5,10 +5,10 @@ VALUES (1, '잠실 야구 경기장', 'main_image_a.jpg', 'seating_chart_a.jpg',
        (3, '부산 야구 경기장', 'main_image_c.jpg', 'seating_chart_c.jpg', 'labeled_seating_chart_c.jpg', 0);
 
 -- Baseball Teams
-INSERT INTO baseball_teams (id, name, alias, logo, label_background_color)
-VALUES (1, 'Team A', 'A', 'logo_a.png', '#FFFFF0'),
-       (2, 'Team B', 'B', 'logo_b.png', '#FFFFF1'),
-       (3, 'Team C', 'C', 'logo_c.png', '#FFFFF2');
+INSERT INTO baseball_teams (id, name, alias, logo, label_background_color, label_font_color)
+VALUES (1, 'Team A', 'A', 'logo_a.png', '#FFFFF0', '#FFFFF0'),
+       (2, 'Team B', 'B', 'logo_b.png', '#FFFFF1', '#FFFFFF'),
+       (3, 'Team C', 'C', 'logo_c.png', '#FFFFF2', '#FFFFFF');
 
 -- Stadium Home Teams
 INSERT INTO stadium_home_teams (id, stadium_id, team_id)

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/team/ReadStadiumHomeTeamUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/team/ReadStadiumHomeTeamUsecase.java
@@ -21,5 +21,6 @@ public interface ReadStadiumHomeTeamUsecase {
         private final Long id;
         private final String alias;
         private final String labelBackgroundColor;
+        private final String labelFontColor;
     }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/StadiumReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/StadiumReadService.java
@@ -45,6 +45,8 @@ public class StadiumReadService implements StadiumReadUsecase {
                                                                             t.getId(),
                                                                             t.getAlias(),
                                                                             t.getLabelBackgroundColor()
+                                                                                    .getValue(),
+                                                                            t.getLabelFontColor()
                                                                                     .getValue()))
                                                     .toList();
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/team/ReadStadiumHomeTeamService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/team/ReadStadiumHomeTeamService.java
@@ -28,7 +28,8 @@ public class ReadStadiumHomeTeamService implements ReadStadiumHomeTeamUsecase {
                                 new HomeTeamInfo(
                                         t.getId(),
                                         t.getAlias(),
-                                        t.getLabelBackgroundColor().getValue()))
+                                        t.getLabelBackgroundColor().getValue(),
+                                        t.getLabelFontColor().getValue()))
                 .toList();
     }
 


### PR DESCRIPTION
## 📌 개요 (필수)

- 구장별 홈 팀 label 폰트 색상을 서버에서 관리해요.
- ref) [관련 스레드](https://depromeet-15th.slack.com/archives/C076JJKKR4H/p1722143725606359)

<br>

## 🔨 작업 사항 (필수)

- BaseballTeam Entity에 폰트 필드 추가
- BaseballTeam 도메인에 폰트 필드 추가
- 관련 테스트코드 수정
- 홈 팀 조회 API들에 res에 폰트 추가
- data.sql 수정

<br>

## 🌱 연관 내용 (선택)

- dev DB에 테이블 alter 날린 후 배포 예정!

<br>

## 💻 실행 화면 (필수)

- 기존에 있던 홈 팀 관련 API res만 슥 수정했어용

전체 경기장 조회 API
<img width="350" alt="스크린샷 2024-08-01 오후 8 55 36" src="https://github.com/user-attachments/assets/7bb3e7dc-d1e0-41bd-aa28-0a201608c6f3">

특정 경기장 조회 API
<img width="291" alt="스크린샷 2024-08-01 오후 8 56 02" src="https://github.com/user-attachments/assets/0ba6a83e-75b2-4b72-818e-94e4ef253359">


