### PR TITLE
[NO_JIRA] 리뷰 작성 API res에 레벨 업데이트 전 멤버 정보가 반환되는 버그

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/review/CreateReviewController.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/CreateReviewController.java
@@ -40,6 +40,6 @@ public class CreateReviewController {
             @RequestBody @Valid CreateReviewRequest request) {
         CreateReviewUsecase.CreateReviewResult result =
                 createReviewUsecase.create(blockId, seatNumber, memberId, request.toCommand());
-        return BaseReviewResponse.from(result.review());
+        return BaseReviewResponse.from(result);
     }
 }

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/BaseReviewResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/BaseReviewResponse.java
@@ -12,6 +12,7 @@ import org.depromeet.spot.domain.review.keyword.Keyword;
 import org.depromeet.spot.domain.seat.Seat;
 import org.depromeet.spot.domain.section.Section;
 import org.depromeet.spot.domain.stadium.Stadium;
+import org.depromeet.spot.usecase.port.in.review.CreateReviewUsecase.CreateReviewResult;
 
 public record BaseReviewResponse(
         Long id,
@@ -25,6 +26,34 @@ public record BaseReviewResponse(
         String content,
         List<ReviewImageResponse> images,
         List<KeywordResponse> keywords) {
+
+    public static BaseReviewResponse from(CreateReviewResult result) {
+        Review review = result.review();
+        Member member = result.member();
+        Seat seat = result.seat();
+        return new BaseReviewResponse(
+                review.getId(),
+                MemberInfo.from(member),
+                StadiumResponse.from(review.getStadium()),
+                SectionResponse.from(review.getSection()),
+                BlockResponse.from(review.getBlock()),
+                RowResponse.from(review.getRow()),
+                SeatResponse.from(seat),
+                review.getDateTime(),
+                review.getContent(),
+                review.getImages().stream().map(ReviewImageResponse::from).toList(),
+                review.getKeywords().stream()
+                        .map(
+                                reviewKeyword -> {
+                                    Keyword keyword =
+                                            review.getKeywordById(reviewKeyword.getKeywordId());
+                                    return new KeywordResponse(
+                                            reviewKeyword.getId(),
+                                            keyword.getContent(),
+                                            keyword.getIsPositive());
+                                })
+                        .toList());
+    }
 
     public static BaseReviewResponse from(Review review) {
         return new BaseReviewResponse(


### PR DESCRIPTION
## 📌 개요 (필수)

- #96 이후 리뷰 작성 API의 res에 유저 레벨이 변경되지 않은 채로 반환되는 이슈 발견
- 원인 : 유스케이스에선 레벨이 업데이트 된 유저 도메인을 반환하는데, 정작 컨트롤러에서 response dto 매핑해줄 때 레벨 업데이트 되기 전의 유저 도메인을 사용하고 있었음

<br>

## 🔨 작업 사항 (필수)

- 리뷰 작성 API res dto 변환 로직 수정
