### PR TITLE
[BSVR-184] 내 리뷰 조회 API res 수정 : 팀이름, 팀 id 포함

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/review/ReadReviewController.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/ReadReviewController.java
@@ -16,6 +16,9 @@ import org.depromeet.spot.application.review.dto.response.MyReviewListResponse;
 import org.depromeet.spot.application.review.dto.response.ReviewMonthsResponse;
 import org.depromeet.spot.domain.review.ReviewYearMonth;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase;
+import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.BlockReviewListResult;
+import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.MyRecentReviewResult;
+import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.MyReviewListResult;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.ReadReviewResult;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
@@ -58,7 +61,7 @@ public class ReadReviewController {
                             direction = Sort.Direction.DESC)
                     Pageable pageable) {
 
-        ReadReviewUsecase.BlockReviewListResult result =
+        BlockReviewListResult result =
                 readReviewUsecase.findReviewsByStadiumIdAndBlockCode(
                         stadiumId,
                         blockCode,
@@ -98,7 +101,7 @@ public class ReadReviewController {
                             direction = Sort.Direction.DESC)
                     Pageable pageable) {
 
-        ReadReviewUsecase.MyReviewListResult result =
+        MyReviewListResult result =
                 readReviewUsecase.findMyReviewsByUserId(
                         memberId, request.year(), request.month(), pageable);
         return MyReviewListResponse.from(result, request.year(), request.month());
@@ -107,11 +110,10 @@ public class ReadReviewController {
     @CurrentMember
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/reviews/recentReview")
-    @Operation(summary = "자신이 작성한 최근 리뷰를 조회한다.")
+    @Operation(summary = "자신이 작성한 가장 최근 리뷰 1개를 조회한다.")
     public MyRecentReviewResponse findMyRecentReview(@Parameter(hidden = true) Long memberId) {
 
-        ReadReviewUsecase.MyRecentReviewResult result =
-                readReviewUsecase.findLastReviewByMemberId(memberId);
+        MyRecentReviewResult result = readReviewUsecase.findLastReviewByMemberId(memberId);
         return MyRecentReviewResponse.from(result);
     }
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
@@ -62,7 +62,8 @@ public interface ReadReviewUsecase {
             Integer level,
             String levelTitle,
             String nickname,
-            Long reviewCount) {}
+            Long reviewCount,
+            Long teamId) {}
 
     @Builder
     record MyRecentReviewResult(Review review, Long reviewCount) {}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
@@ -63,7 +63,8 @@ public interface ReadReviewUsecase {
             String levelTitle,
             String nickname,
             Long reviewCount,
-            Long teamId) {}
+            Long teamId,
+            String teamName) {}
 
     @Builder
     record MyRecentReviewResult(Review review, Long reviewCount) {}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -145,6 +145,7 @@ public class ReadReviewService implements ReadReviewUsecase {
                 .levelTitle(member.getLevel().getTitle())
                 .nickname(member.getNickname())
                 .reviewCount(totalReviewCount)
+                .teamId(member.getTeamId())
                 .build();
     }
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -11,12 +11,14 @@ import org.depromeet.spot.domain.review.ReviewYearMonth;
 import org.depromeet.spot.domain.review.image.TopReviewImage;
 import org.depromeet.spot.domain.review.keyword.Keyword;
 import org.depromeet.spot.domain.review.keyword.ReviewKeyword;
+import org.depromeet.spot.domain.team.BaseballTeam;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase;
 import org.depromeet.spot.usecase.port.out.member.MemberRepository;
 import org.depromeet.spot.usecase.port.out.review.BlockTopKeywordRepository;
 import org.depromeet.spot.usecase.port.out.review.KeywordRepository;
 import org.depromeet.spot.usecase.port.out.review.ReviewImageRepository;
 import org.depromeet.spot.usecase.port.out.review.ReviewRepository;
+import org.depromeet.spot.usecase.port.out.team.BaseballTeamRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -33,6 +35,7 @@ public class ReadReviewService implements ReadReviewUsecase {
     private final BlockTopKeywordRepository blockTopKeywordRepository;
     private final KeywordRepository keywordRepository;
     private final MemberRepository memberRepository;
+    private final BaseballTeamRepository baseballTeamRepository;
 
     private static final int TOP_KEYWORDS_LIMIT = 5;
     private static final int TOP_IMAGES_LIMIT = 5;
@@ -90,8 +93,11 @@ public class ReadReviewService implements ReadReviewUsecase {
 
         Member member = memberRepository.findById(userId);
 
+        BaseballTeam baseballTeam = baseballTeamRepository.findById(member.getTeamId());
+
         MemberInfoOnMyReviewResult memberInfo =
-                createMemberInfoFromMember(member, reviewPage.getTotalElements());
+                createMemberInfoFromMember(
+                        member, reviewPage.getTotalElements(), baseballTeam.getName());
 
         return MyReviewListResult.builder()
                 .memberInfoOnMyReviewResult(memberInfo)
@@ -137,7 +143,7 @@ public class ReadReviewService implements ReadReviewUsecase {
     }
 
     private MemberInfoOnMyReviewResult createMemberInfoFromMember(
-            Member member, long totalReviewCount) {
+            Member member, long totalReviewCount, String teamName) {
         return MemberInfoOnMyReviewResult.builder()
                 .userId(member.getId())
                 .profileImageUrl(member.getProfileImage())
@@ -146,6 +152,7 @@ public class ReadReviewService implements ReadReviewUsecase {
                 .nickname(member.getNickname())
                 .reviewCount(totalReviewCount)
                 .teamId(member.getTeamId())
+                .teamName(teamName)
                 .build();
     }
 


### PR DESCRIPTION
## 📌 개요 (필수)

- 내 리뷰 조회 API res 수정 : 팀이름, 팀 id 포함

<br>

## 🔨 작업 사항 (필수)

- ReadReviewService에서 member의 teamId를 통해 BaseballTeam에서 팀의 이름을 가지고 와서 리뷰를 반환할 때 유저 정보에 pk와 함께 팀 이름을 반환

<br>

## 💻 실행 화면 (필수)

- memberInfoOnMyReview에 teamId와 teamName이 추가되어 아주 잘 반환된다!

![image](https://github.com/user-attachments/assets/2432bf72-af38-46d7-8d84-e02d32e4ff0a)
