### PR TITLE
[NO_JIRA] Member 응원 팀을 nullable로 변경

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/member/dto/request/RegisterReq.java
+++ b/application/src/main/java/org/depromeet/spot/application/member/dto/request/RegisterReq.java
@@ -19,9 +19,11 @@ public record RegisterReq(
                         regexp = "^[a-zA-Z0-9가-힣]*$",
                         message = "닉네임은 알파벳 대소문자, 숫자, 한글만 허용하며, 공백은 불가능합니다.")
                 String nickname,
-        @NotNull(message = "응원 팀 선택은 필수입니다.")
-                @Schema(description = "응원 팀 pk")
-                @Range(min = 1, max = 11, message = "응원 팀은 1번(두산 베어스)부터 11번(없음)까지 입니다.")
+        @Schema(description = "응원 팀 pk")
+                @Range(
+                        min = 1,
+                        max = 10,
+                        message = "응원 팀은 null(모두 응원), 1번(두산 베어스)부터 10번(NC 다이노스)까지 입니다.")
                 Long teamId) {
 
     public Member toDomain() {

--- a/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/entity/MemberEntity.java
+++ b/infrastructure/jpa/src/main/java/org/depromeet/spot/jpa/member/entity/MemberEntity.java
@@ -55,7 +55,7 @@ public class MemberEntity extends BaseEntity {
     @Column(name = "id_token", nullable = false, unique = true, length = 255)
     private String idToken;
 
-    @Column(name = "team_id", nullable = false, length = 10)
+    @Column(name = "team_id", length = 10)
     private Long teamId;
 
     @Column(name = "role", nullable = false)

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/member/MemberUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/member/MemberUsecase.java
@@ -34,6 +34,17 @@ public interface MemberUsecase {
         private String teamImageUrl;
         private final Long teamId;
 
+        public static MemberInfo from(Member member) {
+            return MemberInfo.builder()
+                    .nickname(member.getNickname())
+                    .profileImageUrl(member.getProfileImage())
+                    .level(member.getLevel().getValue())
+                    .levelTitle(member.getLevel().getTitle())
+                    .teamImageUrl(null)
+                    .teamId(null)
+                    .build();
+        }
+
         public static MemberInfo of(Member member, BaseballTeam baseballTeam) {
             return MemberInfo.builder()
                     .nickname(member.getNickname())

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/member/MemberService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/member/MemberService.java
@@ -78,8 +78,10 @@ public class MemberService implements MemberUsecase {
     @Override
     public MemberInfo findMemberInfo(Long memberId) {
         Member member = readMemberUsecase.findById(memberId);
+        if (member.getTeamId() == null) {
+            return MemberInfo.from(member);
+        }
         BaseballTeam baseballTeam = readBaseballTeamUsecase.findById(member.getTeamId());
-
         return MemberInfo.of(member, baseballTeam);
     }
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/member/UpdateMemberService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/member/UpdateMemberService.java
@@ -27,10 +27,16 @@ public class UpdateMemberService implements UpdateMemberUsecase {
     @Override
     public Member updateProfile(final Long memberId, UpdateProfileCommand command) {
         Member member = readMemberUsecase.findById(memberId);
-        readBaseballTeamUsecase.areAllTeamIdsExist(Set.of(command.teamId()));
-        Member updateMember =
-                member.updateProfile(command.profileImage(), command.nickname(), command.teamId());
+        Member updateMember = getUpdateMember(member, command);
         return memberRepository.updateProfile(updateMember);
+    }
+
+    private Member getUpdateMember(Member member, UpdateProfileCommand command) {
+        Long teamId = command.teamId();
+        if (teamId != null) {
+            readBaseballTeamUsecase.areAllTeamIdsExist(Set.of(teamId));
+        }
+        return member.updateProfile(command.profileImage(), command.nickname(), teamId);
     }
 
     @Override


### PR DESCRIPTION
## 📌 개요 (필수)

- 응원하는 팀이 없는 (= 모든 팀 응원) 유저가 존재해요.
- 따라서 Member.teamId를 nullable하게 수정해요.
- [관련 스레드](https://depromeet-15th.slack.com/archives/C075Z9K5QH4/p1722595109574709)

<br>

## 🔨 작업 사항 (필수)

- MemberEntity에서 teamId nullable으로 변경
- 응원 구단이 nullable하게 바뀐것에 영향받는 코드 수정
- members 테이블 team_id를 nullable로 alter (PR merge될 때 개발 DB에 반영 예정)

<br>

## ⚡️ 관심 리뷰 (선택)

- 멤버 부분은 내가 작업했던 코드가 아니라, 혹시 수정 누락된 부분이 있는지 담당자 확인이 필요해요 @wjdwnsdnjs13 

<br>

## 🖥️ 실행 화면

프로필 수정할 때 team null로 넣어도 잘 동작!
<img width="604" alt="스크린샷 2024-08-03 오후 12 41 10" src="https://github.com/user-attachments/assets/9b7e9eaa-1dc2-4ce9-82b4-b42c746a6742">

<img width="396" alt="스크린샷 2024-08-03 오후 12 41 46" src="https://github.com/user-attachments/assets/dc5b4ac4-1d03-41a8-bf16-fedd2de9419c">

