### PR TITLE
[BSVR-185] spring actuator, prometheus, loki 의존성 및 설정

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -6,23 +6,29 @@ dependencies {
     implementation(project(":infrastructure:ncp"))
 
     // spring
+    implementation("org.springframework:spring-aspects")
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("org.springframework:spring-aspects")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa") // pageable
+    implementation("org.springframework.boot:spring-boot-starter-actuator") {
+        because("spring application의 metric 수집 및 모니터링을 위해 추가합니다.")
+    }
+    implementation("org.springframework.boot:spring-boot-starter-validation")
 
     // security
     implementation("org.springframework.boot:spring-boot-starter-security")
+
+    // prometheus
+    implementation("com.github.loki4j:loki-logback-appender:_")
+    runtimeOnly("io.micrometer:micrometer-registry-prometheus:_")
 
     // swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:_")
 
     // jwt
-//    implementation("io.jsonwebtoken:jjwt:_")
-    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
-    implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
-    implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
+    implementation("io.jsonwebtoken:jjwt-api:_")
+    implementation("io.jsonwebtoken:jjwt-impl:_")
+    implementation("io.jsonwebtoken:jjwt-jackson:_")
 
     // aop
     implementation("org.springframework.boot:spring-boot-starter-aop")

--- a/application/src/main/java/org/depromeet/spot/application/common/config/SecurityConfig.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/config/SecurityConfig.java
@@ -28,7 +28,8 @@ public class SecurityConfig {
         "/api-docs/**",
         "/swagger-ui.html",
         "/favicon.ico/**",
-        "/api/v1/members/**"
+        "/api/v1/members/**",
+        "/actuator/**"
     };
 
     @Bean

--- a/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtAuthenticationFilter.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtAuthenticationFilter.java
@@ -34,7 +34,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         "/api-docs",
         "/swagger-ui.html",
         "/favicon.ico",
-        "/api/v1/members"
+        "/api/v1/members",
+        "/actuator"
     };
 
     @Override

--- a/application/src/main/resources/appenders/console-appender.xml
+++ b/application/src/main/resources/appenders/console-appender.xml
@@ -10,4 +10,21 @@
     <appender name="SENTRY_APPENDER" class="io.sentry.logback.SentryAppender">
         <minimumEventLevel>ERROR</minimumEventLevel>
     </appender>
+
+    <appender name="LOKI_APPENDER" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <!-- TODO: Loki 인스턴스 세팅 후 URL 변경 필요 -->
+            <url>http://localhost:3100/loki/api/v1/push</url>
+        </http>
+        <format>
+            <label>
+                <pattern>app=${name},host=${HOSTNAME},level=%level</pattern>
+                <readMarkers>true</readMarkers>
+            </label>
+            <message>
+                <pattern>%highlight([%-5level]) %d{yy-MM-dd HH:mm:ss.SSS} %green([%thread]) %yellow([traceId=%X{traceId}]) %cyan([%logger{0}:%line])-%message%n</pattern>
+            </message>
+            <sortByTime>true</sortByTime>
+        </format>
+    </appender>
 </included>

--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -7,22 +7,22 @@ spring:
     profiles:
         active: local
         group:
-          local:
-              - jpa
-              - ncp
-              - jwt
-              - kakao
-          dev:
-              - jpa
-              - ncp
-              - jwt
-              - kakao
-          prod:
-              - jpa
-              - ncp
-              - jwt
-              - kakao
-              - sentry
+            local:
+                - jpa
+                - ncp
+                - jwt
+                - kakao
+            dev:
+                - jpa
+                - ncp
+                - jwt
+                - kakao
+            prod:
+                - jpa
+                - ncp
+                - jwt
+                - kakao
+                - sentry
     servlet:
         multipart:
             max-file-size: 10MB
@@ -45,12 +45,12 @@ management:
             enabled: true
         web:
             exposure:
-                include: prometheus
+                include: "*"
 ---
 spring:
     config:
-      activate:
-          on-profile: local
+        activate:
+            on-profile: local
 ---
 spring:
     config:
@@ -68,5 +68,5 @@ decorator:
             enable-logging: false
 
 springdoc:
-  swagger-ui:
-      enabled: false
+    swagger-ui:
+        enabled: false

--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -37,6 +37,15 @@ decorator:
     datasource:
         p6spy:
             enable-logging: true
+
+# spring actuator
+management:
+    endpoints:
+        prometheus:
+            enabled: true
+        web:
+            exposure:
+                include: prometheus
 ---
 spring:
     config:

--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -40,6 +40,8 @@ decorator:
 
 # spring actuator
 management:
+    server:
+        port: 9292
     endpoints:
         prometheus:
             enabled: true

--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -42,6 +42,9 @@ decorator:
 management:
     server:
         port: 9292
+    endpoint:
+      health:
+          show-details: always
     endpoints:
         prometheus:
             enabled: true

--- a/application/src/main/resources/logback-spring.xml
+++ b/application/src/main/resources/logback-spring.xml
@@ -18,6 +18,7 @@
         <root level="ERROR">
             <appender-ref ref="CONSOLE_APPENDER"/>
             <appender-ref ref="SENTRY_APPENDER"/>
+            <appender-ref ref="LOKI_APPENDER"/>
         </root>
     </springProfile>
 </configuration>

--- a/versions.properties
+++ b/versions.properties
@@ -40,3 +40,13 @@ version.org.springframework.boot..spring-boot-configuration-processor=3.0.1
 version.io.sentry..sentry-logback=7.12.0
 
 version.io.sentry..sentry-spring-boot-starter-jakarta=7.12.0
+
+version.io.jsonwebtoken..jjwt-api=0.11.5
+
+version.io.jsonwebtoken..jjwt-impl=0.11.5
+
+version.io.jsonwebtoken..jjwt-jackson=0.11.5
+
+version.com.github.loki4j..loki-logback-appender=1.4.2
+
+version.io.micrometer..micrometer-registry-prometheus=1.12.4


### PR DESCRIPTION
## 📌 개요 (필수)

- 서버 모니터링 파이프라인 구축을 위해, 스프링에서 필요한 설정을 추가해요.

<br>

## 🔨 작업 사항 (필수)

- spring actuator, prometheus, loki 의존성 추가
- actuator, prometheus endpoint 활성화 및 인증 필터에서 제외
- loki appender 생성 및 prod에 적용

<br>

## 🌱 연관 내용 (선택)

- 기본 spring 포트인 8080을 그대로 쓰면 외부에서 actuator metric에 접근 가능할 것 같아서, 내부만 접근 가능하도록 9292 포트를 열었어요. ec2 설정할 때 참고!
- 주석으로 남겨놨는데, 나중에 loki 인스턴스가 세팅되면 loki appender의 url을 인스턴스 주소로 바꿔줘야 해요.

<br>

## 💻 실행 화면 (필수)

- actuator 리스트
<img width="732" alt="스크린샷 2024-08-03 오후 7 36 58" src="https://github.com/user-attachments/assets/95185976-415b-40de-9d2b-1eb3ef9957ea">

- prometheus 메트릭 활성화 확인
<img width="755" alt="스크린샷 2024-08-03 오후 7 37 18" src="https://github.com/user-attachments/assets/9b2de9c4-4dae-437b-bdfa-3de1c74e18eb">


