### PR TITLE
[NO_JIRA] 홈 피드 API teamId null 시 발생하는 오류 수정

### DIFF
--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/member/MemberUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/member/MemberUsecase.java
@@ -37,14 +37,17 @@ public interface MemberUsecase {
         private final String teamName;
         private final Long reviewCntToLevelUp;
 
-        public static MemberInfo from(Member member) {
+        public static MemberInfo of(Member member, Long reviewCntToLevelUp) {
             return MemberInfo.builder()
                     .nickname(member.getNickname())
                     .profileImageUrl(member.getProfileImage())
                     .level(member.getLevel().getValue())
                     .levelTitle(member.getLevel().getTitle())
+                    .mascotImageUrl(member.getLevel().getMascotImageUrl())
                     .teamImageUrl(null)
                     .teamId(null)
+                    .teamName(null)
+                    .reviewCntToLevelUp(reviewCntToLevelUp)
                     .build();
         }
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/member/MemberService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/member/MemberService.java
@@ -81,13 +81,13 @@ public class MemberService implements MemberUsecase {
     @Override
     public MemberInfo findMemberInfo(Long memberId) {
         Member member = readMemberUsecase.findById(memberId);
-        if (member.getTeamId() == null) {
-            return MemberInfo.from(member);
-        }
-        BaseballTeam baseballTeam = readBaseballTeamUsecase.findById(member.getTeamId());
-
         long reviewCount = readReviewUsecase.countByIdByMemberId(memberId);
         long reviewCntToLevelUp = Level.calculateReviewCntToLevelUp(reviewCount);
+
+        if (member.getTeamId() == null) {
+            return MemberInfo.of(member, reviewCntToLevelUp);
+        }
+        BaseballTeam baseballTeam = readBaseballTeamUsecase.findById(member.getTeamId());
 
         return MemberInfo.of(member, baseballTeam, reviewCntToLevelUp);
     }


### PR DESCRIPTION
## 📌 개요 (필수)

- 홈 피드 API teamId null 시 발생하는 오류 수정
```
{
  "level": 6,
  "teamName": null,
  "teamId": null,
  "levelTitle": "전설의 직관러",
  "reviewCntToLevelUp": null,
  "mascotImageUrl": null
}
```

<br>

## 🔨 작업 사항 (필수)

- MemberInfo 변환 시 build 누락 휴먼 에러 수정
- teamId null 시 리턴 이후 리뷰 카운트 로직이 들어있던 부분 수정

<br>

## 💻 실행 화면 (필수)

- 수정 완료!
![image](https://github.com/user-attachments/assets/7af83f49-32e4-4fe6-94f2-94b0c3d209c4)

