### PR TITLE
[NO_JIRA] reviews teamId null 일 때 오류 fix

### DIFF
--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
@@ -2,6 +2,7 @@ package org.depromeet.spot.usecase.port.in.review;
 
 import java.util.List;
 
+import org.depromeet.spot.domain.member.Member;
 import org.depromeet.spot.domain.review.Review;
 import org.depromeet.spot.domain.review.ReviewYearMonth;
 import org.depromeet.spot.domain.review.image.TopReviewImage;
@@ -66,7 +67,34 @@ public interface ReadReviewUsecase {
             String nickname,
             Long reviewCount,
             Long teamId,
-            String teamName) {}
+            String teamName) {
+        public static MemberInfoOnMyReviewResult of(Member member, long totalReviewCount) {
+            return MemberInfoOnMyReviewResult.builder()
+                    .userId(member.getId())
+                    .profileImageUrl(member.getProfileImage())
+                    .level(member.getLevel().getValue())
+                    .levelTitle(member.getLevel().getTitle())
+                    .nickname(member.getNickname())
+                    .reviewCount(totalReviewCount)
+                    .teamId(null)
+                    .teamName(null)
+                    .build();
+        }
+
+        public static MemberInfoOnMyReviewResult of(
+                Member member, long totalReviewCount, String teamName) {
+            return MemberInfoOnMyReviewResult.builder()
+                    .userId(member.getId())
+                    .profileImageUrl(member.getProfileImage())
+                    .level(member.getLevel().getValue())
+                    .levelTitle(member.getLevel().getTitle())
+                    .nickname(member.getNickname())
+                    .reviewCount(totalReviewCount)
+                    .teamId(member.getTeamId())
+                    .teamName(teamName)
+                    .build();
+        }
+    }
 
     @Builder
     record MyRecentReviewResult(Review review, Long reviewCount) {}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -93,11 +93,17 @@ public class ReadReviewService implements ReadReviewUsecase {
 
         Member member = memberRepository.findById(userId);
 
-        BaseballTeam baseballTeam = baseballTeamRepository.findById(member.getTeamId());
+        MemberInfoOnMyReviewResult memberInfo;
+        if (member.getTeamId() == null) {
+            memberInfo = MemberInfoOnMyReviewResult.of(member, reviewPage.getTotalElements());
 
-        MemberInfoOnMyReviewResult memberInfo =
-                createMemberInfoFromMember(
-                        member, reviewPage.getTotalElements(), baseballTeam.getName());
+        } else {
+            BaseballTeam baseballTeam = baseballTeamRepository.findById(member.getTeamId());
+
+            memberInfo =
+                    MemberInfoOnMyReviewResult.of(
+                            member, reviewPage.getTotalElements(), baseballTeam.getName());
+        }
 
         return MyReviewListResult.builder()
                 .memberInfoOnMyReviewResult(memberInfo)

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -147,20 +147,6 @@ public class ReadReviewService implements ReadReviewUsecase {
                 .build();
     }
 
-    private MemberInfoOnMyReviewResult createMemberInfoFromMember(
-            Member member, long totalReviewCount, String teamName) {
-        return MemberInfoOnMyReviewResult.builder()
-                .userId(member.getId())
-                .profileImageUrl(member.getProfileImage())
-                .level(member.getLevel().getValue())
-                .levelTitle(member.getLevel().getTitle())
-                .nickname(member.getNickname())
-                .reviewCount(totalReviewCount)
-                .teamId(member.getTeamId())
-                .teamName(teamName)
-                .build();
-    }
-
     private Review mapKeywordsToSingleReview(Review review) {
         List<Long> keywordIds =
                 review.getKeywords().stream()


### PR DESCRIPTION
## 📌 개요 (필수)

- reviews API teamId == null 오류 fix

<br>

## 🔨 작업 사항 (필수)

- reviews API teamId == null 일 때 분기 처리
- MemberInfoOnMyReviewResult 변환 메서드 해당 클래스 멤버 메서드로 리팩토링

<br>

## 💻 실행 화면 (필수)

- teamId == null 일 때 성공!
![image](https://github.com/user-attachments/assets/a8a0dc93-1b27-41ae-a379-09a31a5fa9d8)

