### PR TITLE
[BSVR-166] 로컬 캐시 적용

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/common/config/SpotApplicationConfig.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/config/SpotApplicationConfig.java
@@ -1,6 +1,7 @@
 package org.depromeet.spot.application.common.config;
 
 import org.depromeet.spot.infrastructure.aws.AwsConfig;
+import org.depromeet.spot.infrastructure.cache.config.CacheConfig;
 import org.depromeet.spot.infrastructure.jpa.config.JpaConfig;
 import org.depromeet.spot.usecase.config.UsecaseConfig;
 import org.springframework.context.annotation.ComponentScan;
@@ -9,5 +10,12 @@ import org.springframework.context.annotation.Import;
 
 @ComponentScan(basePackages = {"org.depromeet.spot.application"})
 @Configuration
-@Import(value = {UsecaseConfig.class, JpaConfig.class, AwsConfig.class, SwaggerConfig.class})
+@Import(
+        value = {
+            UsecaseConfig.class,
+            JpaConfig.class,
+            AwsConfig.class,
+            CacheConfig.class,
+            SwaggerConfig.class
+        })
 public class SpotApplicationConfig {}

--- a/infrastructure/build.gradle.kts
+++ b/infrastructure/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     // spring
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa:_")
 
     // mysql
@@ -25,6 +26,9 @@ dependencies {
 
     // webflux (HTTP 요청에 사용)
     implementation("org.springframework.boot:spring-boot-starter-webflux")
+
+    // caffeine cache
+    implementation("com.github.ben-manes.caffeine:caffeine:_")
 }
 
 tasks.bootJar { enabled = false }

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/cache/CacheType.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/cache/CacheType.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public enum CacheType {
     SECTION_SEATS("sectionSeatsCache", 100L, 60 * 60 * 24L),
     BLOCK_SEATS("blockSeatsCache", 1_000L, 60 * 60 * 24L),
-    LEVEL_INFO("levelsCache", 10L, 60 * 60 * 24L),
+    LEVEL_INFO("levelsCache", 1L, 60 * 60 * 24L),
     ;
 
     private final String name;

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/cache/CacheType.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/cache/CacheType.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum CacheType {
-    SECTION_SEATS("sectionSeatsCache", 50_000L, 60 * 60 * 24L),
+    SECTION_SEATS("sectionSeatsCache", 100L, 60 * 60 * 24L),
     BLOCK_SEATS("blockSeatsCache", 1_000L, 60 * 60 * 24L),
     LEVEL_INFO("levelsCache", 10L, 60 * 60 * 24L),
     ;

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/cache/CacheType.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/cache/CacheType.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum CacheType {
-    BLOCK_SEATS("blockSeatsCache", 50_000L, 60 * 60 * 24L),
+    SECTION_SEATS("sectionSeatsCache", 50_000L, 60 * 60 * 24L),
+    BLOCK_SEATS("blockSeatsCache", 1_000L, 60 * 60 * 24L),
     LEVEL_INFO("levelsCache", 10L, 60 * 60 * 24L),
     ;
 

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/cache/CacheType.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/cache/CacheType.java
@@ -1,0 +1,3 @@
+package org.depromeet.spot.infrastructure.cache;
+
+public enum CacheType {}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/cache/CacheType.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/cache/CacheType.java
@@ -1,3 +1,16 @@
 package org.depromeet.spot.infrastructure.cache;
 
-public enum CacheType {}
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CacheType {
+    BLOCK_SEATS("blockSeatsCache", 50_000L, 60 * 60 * 24L),
+    LEVEL_INFO("levelsCache", 10L, 60 * 60 * 24L),
+    ;
+
+    private final String name;
+    private final Long size;
+    private final Long expireSeconds;
+}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/cache/CacheType.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/cache/CacheType.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public enum CacheType {
     SECTION_SEATS("sectionSeatsCache", 100L, 60 * 60 * 24L),
     BLOCK_SEATS("blockSeatsCache", 1_000L, 60 * 60 * 24L),
-    LEVEL_INFO("levelsCache", 1L, 60 * 60 * 24L),
+    LEVEL_INFO("levelsCache", 1L, 60 * 60 * 1L),
     ;
 
     private final String name;

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/cache/config/CacheConfig.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/cache/config/CacheConfig.java
@@ -1,3 +1,53 @@
 package org.depromeet.spot.infrastructure.cache.config;
 
-public class CacheConfig {}
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.depromeet.spot.infrastructure.cache.CacheType;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        getCaches().forEach(cache -> cacheManager.setCaches(getCaches()));
+        return cacheManager;
+    }
+
+    public List<Cache> getCaches() {
+        return Arrays.stream(CacheType.values()).map(this::createCache).toList();
+    }
+
+    private Cache createCache(CacheType type) {
+        return new CaffeineCache(
+                type.getName(),
+                Caffeine.newBuilder()
+                        .softValues()
+                        .recordStats()
+                        .maximumSize(type.getSize())
+                        .expireAfterWrite(type.getExpireSeconds(), TimeUnit.SECONDS)
+                        .removalListener(
+                                ((key, value, cause) ->
+                                        log.debug(
+                                                "key: {}, value: {}의 캐시가 {}로 인해 제거되었어요.",
+                                                key,
+                                                value,
+                                                cause)))
+                        .build());
+    }
+}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/cache/config/CacheConfig.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/cache/config/CacheConfig.java
@@ -1,0 +1,3 @@
+package org.depromeet.spot.infrastructure.cache.config;
+
+public class CacheConfig {}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/cache/config/CacheConfig.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/cache/config/CacheConfig.java
@@ -14,6 +14,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Scheduler;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -40,6 +41,7 @@ public class CacheConfig {
                         .softValues()
                         .recordStats()
                         .maximumSize(type.getSize())
+                        .scheduler(Scheduler.systemScheduler())
                         .expireAfterWrite(type.getExpireSeconds(), TimeUnit.SECONDS)
                         .removalListener(
                                 ((key, value, cause) ->

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/seat/repository/SeatJpaRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/seat/repository/SeatJpaRepository.java
@@ -29,7 +29,21 @@ public interface SeatJpaRepository extends JpaRepository<SeatEntity, Long> {
     Optional<SeatEntity> findByIdWith(
             @Param("blockId") Long blockId, @Param("seatNumber") Integer seatNumber);
 
-    List<SeatEntity> findAllByBlockId(Long blockId);
+    @Query(
+            "SELECT s FROM SeatEntity s "
+                    + "JOIN FETCH s.stadium st "
+                    + "JOIN FETCH s.section sc "
+                    + "JOIN FETCH s.block b "
+                    + "JOIN FETCH s.row r "
+                    + "where s.block.id = :blockId")
+    List<SeatEntity> findAllByBlockId(@Param("blockId") Long blockId);
 
-    List<SeatEntity> findAllBySectionId(Long sectionId);
+    @Query(
+            "SELECT s FROM SeatEntity s "
+                    + "JOIN FETCH s.stadium st "
+                    + "JOIN FETCH s.section sc "
+                    + "JOIN FETCH s.block b "
+                    + "JOIN FETCH s.row r "
+                    + "where s.section.id = :sectionId")
+    List<SeatEntity> findAllBySectionId(@Param("sectionId") Long sectionId);
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/block/BlockReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/block/BlockReadService.java
@@ -17,6 +17,7 @@ import org.depromeet.spot.usecase.port.in.seat.ReadSeatUsecase;
 import org.depromeet.spot.usecase.port.in.section.SectionReadUsecase;
 import org.depromeet.spot.usecase.port.in.stadium.StadiumReadUsecase;
 import org.depromeet.spot.usecase.port.out.block.BlockRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,6 +44,9 @@ public class BlockReadService implements BlockReadUsecase {
     }
 
     @Override
+    @Cacheable(
+            cacheNames = {"sectionSeatsCache"},
+            key = "#stadiumId + '_' + #sectionId")
     public List<BlockInfo> findAllBlockInfoBy(final Long stadiumId, final Long sectionId) {
         stadiumReadUsecase.checkIsExistsBy(stadiumId);
         sectionReadUsecase.checkIsExistsInStadium(stadiumId, sectionId);
@@ -58,6 +62,9 @@ public class BlockReadService implements BlockReadUsecase {
     }
 
     @Override
+    @Cacheable(
+            cacheNames = {"blockSeatsCache"},
+            key = "#stadiumId + '_' + #blockCode")
     public BlockInfo findBlockInfoBy(final Long stadiumId, final String blockCode) {
         stadiumReadUsecase.checkIsExistsBy(stadiumId);
         Block block = findByStadiumAndCode(stadiumId, blockCode);

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/level/LevelService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/level/LevelService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.depromeet.spot.domain.member.Level;
 import org.depromeet.spot.usecase.port.in.member.LevelUsecase;
 import org.depromeet.spot.usecase.port.out.member.LevelRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +19,7 @@ public class LevelService implements LevelUsecase {
     private final LevelRepository levelRepository;
 
     @Override
+    @Cacheable(cacheNames = {"levelsCache"})
     public List<Level> findAllLevels() {
         return levelRepository.findAll();
     }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/seat/ReadSeatService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/seat/ReadSeatService.java
@@ -11,7 +11,9 @@ import org.depromeet.spot.usecase.port.out.seat.SeatRepository;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ReadSeatService implements ReadSeatUsecase {

--- a/versions.properties
+++ b/versions.properties
@@ -50,3 +50,5 @@ version.io.jsonwebtoken..jjwt-jackson=0.11.5
 version.com.github.loki4j..loki-logback-appender=1.4.2
 
 version.io.micrometer..micrometer-registry-prometheus=1.12.4
+
+version.com.github.ben-manes.caffeine..caffeine=3.1.8


### PR DESCRIPTION
## 📌 개요 (필수)

- caffeine 캐시를 추가하고, 몇몇 데이터에 캐시를 적용해요.
- resolve #88 

<br>

## 🔨 작업 사항 (필수)

- 스프링 캐시, 카페인 캐시 설정 추가
- 구역별 좌석 정보, 블럭별 좌석 정보, 레벨 정보 캐시 추가

<br>

## 🌱 연관 내용 (선택)

- 배포 후 
  - 메모리 사용량 보면서 조정 필요
    - 잘 변하지 않으면서 자주 조회되는 값이라 캐시를 적용하긴 했는데, 적용 이전에도 5-600ms라서 엄청 느리진 않아요.
    - 메모리 점유율이 높고, 인스턴스 스펙이 부족하다면, 그때 캐시 조정 여부 논의하면 될 듯!
  - time-based evice 잘 되는지 모니터링 필요
