### PR TITLE
[BSVR-188] Level up 다이얼로그용 API

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtAuthenticationFilter.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/jwt/JwtAuthenticationFilter.java
@@ -36,7 +36,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         "/favicon.ico",
         "/api/v1/members",
         "/actuator",
-        "/api/v1/levelUpConditions",
+        "/api/v1/levels/info",
         "/api/v1/baseball-teams",
     };
 

--- a/application/src/main/java/org/depromeet/spot/application/member/controller/ReadLevelController.java
+++ b/application/src/main/java/org/depromeet/spot/application/member/controller/ReadLevelController.java
@@ -2,11 +2,17 @@ package org.depromeet.spot.application.member.controller;
 
 import java.util.List;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import org.depromeet.spot.application.member.dto.response.LevelUpDialogInfo;
 import org.depromeet.spot.application.member.dto.response.LevelUpTableResponse;
+import org.depromeet.spot.domain.member.Level;
 import org.depromeet.spot.usecase.port.in.member.LevelUsecase;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,15 +23,23 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "레벨")
-@RequestMapping("/api/v1/levelUpConditions")
-public class LevelUpTableController {
+@RequestMapping("/api/v1/levels")
+public class ReadLevelController {
 
     private final LevelUsecase levelUsecase;
 
-    @GetMapping
+    @GetMapping("/info")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "레벨업 조건 테이블 조회 API")
     public List<LevelUpTableResponse> getLevelUpTable() {
         return levelUsecase.findAllLevels().stream().map(LevelUpTableResponse::from).toList();
+    }
+
+    @GetMapping("/up/info")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "레벨업 다이얼로그 조회 API")
+    public LevelUpDialogInfo getLevelUpDialogInfo(@RequestParam @NotNull @Positive int nextLevel) {
+        Level level = levelUsecase.findLevelUpDialogInfo(nextLevel);
+        return LevelUpDialogInfo.from(level);
     }
 }

--- a/application/src/main/java/org/depromeet/spot/application/member/dto/response/LevelUpDialogInfo.java
+++ b/application/src/main/java/org/depromeet/spot/application/member/dto/response/LevelUpDialogInfo.java
@@ -1,0 +1,10 @@
+package org.depromeet.spot.application.member.dto.response;
+
+import org.depromeet.spot.domain.member.Level;
+
+public record LevelUpDialogInfo(String title, String levelUpImage) {
+
+    public static LevelUpDialogInfo from(Level level) {
+        return new LevelUpDialogInfo(level.getTitle(), level.getLevelUpImageUrl());
+    }
+}

--- a/domain/src/main/java/org/depromeet/spot/domain/member/Level.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/member/Level.java
@@ -34,6 +34,7 @@ public class Level {
     private final int value;
     private final String title;
     private final String mascotImageUrl;
+    private final String levelUpImageUrl;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
     private final LocalDateTime deletedAt;

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/member/entity/LevelEntity.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/member/entity/LevelEntity.java
@@ -25,15 +25,23 @@ public class LevelEntity extends BaseEntity {
     @Column(name = "mascot_image_url")
     private String mascotImageUrl;
 
+    @Column(name = "level_up_image_url")
+    private String levelUpImageUrl;
+
     public LevelEntity(Level level) {
         super(level.getId(), level.getCreatedAt(), level.getUpdatedAt(), level.getDeletedAt());
         value = level.getValue();
         title = level.getTitle();
         mascotImageUrl = level.getMascotImageUrl();
+        levelUpImageUrl = level.getLevelUpImageUrl();
     }
 
     public static LevelEntity from(Level level) {
-        return new LevelEntity(level.getValue(), level.getTitle(), level.getMascotImageUrl());
+        return new LevelEntity(
+                level.getValue(),
+                level.getTitle(),
+                level.getMascotImageUrl(),
+                level.getLevelUpImageUrl());
     }
 
     public Level toDomain() {
@@ -42,6 +50,7 @@ public class LevelEntity extends BaseEntity {
                 value,
                 title,
                 mascotImageUrl,
+                levelUpImageUrl,
                 this.getCreatedAt(),
                 this.getUpdatedAt(),
                 this.getDeletedAt());

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/member/repository/LevelJpaRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/member/repository/LevelJpaRepository.java
@@ -1,9 +1,11 @@
 package org.depromeet.spot.infrastructure.jpa.member.repository;
 
+import java.util.Optional;
+
 import org.depromeet.spot.infrastructure.jpa.member.entity.LevelEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LevelJpaRepository extends JpaRepository<LevelEntity, Long> {
 
-    LevelEntity findByValue(int value);
+    Optional<LevelEntity> findByValue(int value);
 }

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/member/repository/LevelRepositoryImpl.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/member/repository/LevelRepositoryImpl.java
@@ -2,6 +2,7 @@ package org.depromeet.spot.infrastructure.jpa.member.repository;
 
 import java.util.List;
 
+import org.depromeet.spot.common.exception.member.MemberException.InvalidLevelException;
 import org.depromeet.spot.domain.member.Level;
 import org.depromeet.spot.infrastructure.jpa.member.entity.LevelEntity;
 import org.depromeet.spot.usecase.port.out.member.LevelRepository;
@@ -17,7 +18,9 @@ public class LevelRepositoryImpl implements LevelRepository {
 
     @Override
     public Level findByValue(final int value) {
-        return levelJpaRepository.findByValue(value).toDomain();
+        LevelEntity entity =
+                levelJpaRepository.findByValue(value).orElseThrow(InvalidLevelException::new);
+        return entity.toDomain();
     }
 
     @Override

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewJpaRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewJpaRepository.java
@@ -14,7 +14,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ReviewJpaRepository extends JpaRepository<ReviewEntity, Long> {
-    long countByMemberId(Long memberId);
+    long countByMemberIdAndDeletedAtIsNull(Long memberId);
 
     @Query(
             "SELECT r FROM ReviewEntity r WHERE r.stadium.id = :stadiumId AND r.block.code = :blockCode "

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewRepositoryImpl.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewRepositoryImpl.java
@@ -37,7 +37,7 @@ public class ReviewRepositoryImpl implements ReviewRepository {
 
     @Override
     public long countByUserId(Long id) {
-        return reviewJpaRepository.countByMemberId(id);
+        return reviewJpaRepository.countByMemberIdAndDeletedAtIsNull(id);
     }
 
     @Override

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/member/LevelUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/member/LevelUsecase.java
@@ -6,4 +6,6 @@ import org.depromeet.spot.domain.member.Level;
 
 public interface LevelUsecase {
     List<Level> findAllLevels();
+
+    Level findLevelUpDialogInfo(int nextLevel);
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/level/LevelService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/level/LevelService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.depromeet.spot.domain.member.Level;
 import org.depromeet.spot.usecase.port.in.member.LevelUsecase;
+import org.depromeet.spot.usecase.port.in.member.ReadLevelUsecase;
 import org.depromeet.spot.usecase.port.out.member.LevelRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,9 +17,15 @@ import lombok.RequiredArgsConstructor;
 public class LevelService implements LevelUsecase {
 
     private final LevelRepository levelRepository;
+    private final ReadLevelUsecase readLevelUsecase;
 
     @Override
     public List<Level> findAllLevels() {
         return levelRepository.findAll();
+    }
+
+    @Override
+    public Level findLevelUpDialogInfo(final int nextLevel) {
+        return readLevelUsecase.findByValue(nextLevel);
     }
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- 레벨업 다이얼로그 GUI가 추가되었어요.
- [관련 스레드](https://depromeet-15th.slack.com/archives/C075Z9K5QH4/p1722706109884659)

<br>

## 🔨 작업 사항 (필수)

- 레벨 도메인, 레벨 엔티티에 레벨업 이미지 필드 추가
- 레벨업 정보 조회 API 추가
- 유저의 리뷰 수 조회할 때 삭제된 리뷰도 count하는 이슈 수정

<br>

## 🌱 연관 내용 (선택)

- PR merge 전 DB alter 예정

<br>

## 💻 실행 화면 (필수)
<img width="479" alt="스크린샷 2024-08-04 오전 3 56 25" src="https://github.com/user-attachments/assets/b0fbc654-31ca-4b41-8507-c16ef4b81cb1">
