### PR TITLE
[NO_JIRA] 리뷰 삭제시 멤버 레벨 재조정

### DIFF
--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
@@ -32,6 +32,8 @@ public interface ReadReviewUsecase {
 
     long countByIdByMemberId(Long memberId);
 
+    long countByMember(Long memberId);
+
     @Builder
     record BlockReviewListResult(
             LocationInfo location,

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/CreateReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/CreateReviewService.java
@@ -12,6 +12,7 @@ import org.depromeet.spot.domain.review.keyword.ReviewKeyword;
 import org.depromeet.spot.domain.seat.Seat;
 import org.depromeet.spot.usecase.port.in.member.UpdateMemberUsecase;
 import org.depromeet.spot.usecase.port.in.review.CreateReviewUsecase;
+import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase;
 import org.depromeet.spot.usecase.port.out.member.MemberRepository;
 import org.depromeet.spot.usecase.port.out.review.BlockTopKeywordRepository;
 import org.depromeet.spot.usecase.port.out.review.KeywordRepository;
@@ -34,6 +35,7 @@ public class CreateReviewService implements CreateReviewUsecase {
     private final KeywordRepository keywordRepository;
     private final BlockTopKeywordRepository blockTopKeywordRepository;
     private final UpdateMemberUsecase updateMemberUsecase;
+    private final ReadReviewUsecase readReviewUsecase;
 
     @Override
     @Transactional
@@ -78,7 +80,7 @@ public class CreateReviewService implements CreateReviewUsecase {
     }
 
     public Member calculateMemberLevel(final Member member) {
-        final long memberReviewCnt = reviewRepository.countByUserId(member.getId());
+        final long memberReviewCnt = readReviewUsecase.countByMember(member.getId());
         return updateMemberUsecase.updateLevel(member, memberReviewCnt);
     }
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/DeleteReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/DeleteReviewService.java
@@ -1,6 +1,10 @@
 package org.depromeet.spot.usecase.service.review;
 
+import org.depromeet.spot.domain.member.Member;
+import org.depromeet.spot.usecase.port.in.member.ReadMemberUsecase;
+import org.depromeet.spot.usecase.port.in.member.UpdateMemberUsecase;
 import org.depromeet.spot.usecase.port.in.review.DeleteReviewUsecase;
+import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase;
 import org.depromeet.spot.usecase.port.out.review.ReviewRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,10 +16,21 @@ import lombok.RequiredArgsConstructor;
 public class DeleteReviewService implements DeleteReviewUsecase {
 
     private final ReviewRepository reviewRepository;
+    private final ReadReviewUsecase readReviewUsecase;
+    private final UpdateMemberUsecase updateMemberUsecase;
+    private final ReadMemberUsecase readMemberUsecase;
 
     @Override
     @Transactional
     public Long deleteReview(Long reviewId, Long memberId) {
-        return reviewRepository.softDeleteByIdAndMemberId(reviewId, memberId);
+        Long deletedReviewId = reviewRepository.softDeleteByIdAndMemberId(reviewId, memberId);
+        updateMemberLevel(memberId);
+        return deletedReviewId;
+    }
+
+    public void updateMemberLevel(Long memberId) {
+        Member member = readMemberUsecase.findById(memberId);
+        long reviewCnt = readReviewUsecase.countByMember(memberId);
+        updateMemberUsecase.updateLevel(member, reviewCnt);
     }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -140,6 +140,11 @@ public class ReadReviewService implements ReadReviewUsecase {
     }
 
     @Override
+    public long countByMember(Long memberId) {
+        return reviewRepository.countByUserId(memberId);
+    }
+
+    @Override
     public MyRecentReviewResult findLastReviewByMemberId(Long memberId) {
         Review review = reviewRepository.findLastReviewByMemberId(memberId);
 


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #112 

<br>

## 🔨 작업 사항 (필수)

- 리뷰를 삭제한 후, 멤버 레벨을 재조정해요.

<br>

## 💻 실행 화면 (필수)

- 로컬에서 리뷰 삭제 후, 레벨 떨어지는 것 확인완료
<img width="544" alt="스크린샷 2024-08-04 오전 4 33 13" src="https://github.com/user-attachments/assets/aa2dabdc-6885-45d0-88de-61542e23cd8d">

<img width="443" alt="스크린샷 2024-08-04 오전 4 33 39" src="https://github.com/user-attachments/assets/e3352b61-1939-4d30-ac34-258a4437f186">
