### PR TITLE
[BSVR-199] section, baseballTeam의 label color 삭제

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/section/dto/request/CreateSectionRequest.java
+++ b/application/src/main/java/org/depromeet/spot/application/section/dto/request/CreateSectionRequest.java
@@ -14,10 +14,9 @@ public record CreateSectionRequest(
                 String name,
         @Parameter(description = "구역 별칭", example = "응원석")
                 @Length(max = 20, message = "별칭은 최대 20글자 까지만 입력할 수 있습니다.")
-                String alias,
-        @NotBlank String color) {
+                String alias) {
 
     public CreateSectionCommand toCommand() {
-        return CreateSectionCommand.builder().name(name).alias(alias).labelColor(color).build();
+        return CreateSectionCommand.builder().name(name).alias(alias).build();
     }
 }

--- a/application/src/main/java/org/depromeet/spot/application/section/dto/response/SectionInfoResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/section/dto/response/SectionInfoResponse.java
@@ -5,14 +5,13 @@ import org.depromeet.spot.usecase.port.in.section.SectionReadUsecase.SectionInfo
 import lombok.Builder;
 
 @Builder
-public record SectionInfoResponse(Long id, String name, String alias, String color) {
+public record SectionInfoResponse(Long id, String name, String alias) {
 
     public static SectionInfoResponse from(SectionInfo sectionInfo) {
         return SectionInfoResponse.builder()
                 .id(sectionInfo.getId())
                 .name(sectionInfo.getName())
                 .alias(sectionInfo.getAlias())
-                .color(sectionInfo.getColor())
                 .build();
     }
 }

--- a/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/HomeTeamInfoResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/HomeTeamInfoResponse.java
@@ -2,14 +2,10 @@ package org.depromeet.spot.application.stadium.dto.response;
 
 import org.depromeet.spot.usecase.port.in.team.ReadStadiumHomeTeamUsecase.HomeTeamInfo;
 
-public record HomeTeamInfoResponse(
-        Long id, String alias, String backgroundColor, String fontColor) {
+public record HomeTeamInfoResponse(Long id, String alias, String fontColor) {
 
     public static HomeTeamInfoResponse from(HomeTeamInfo homeTeamInfo) {
         return new HomeTeamInfoResponse(
-                homeTeamInfo.getId(),
-                homeTeamInfo.getAlias(),
-                homeTeamInfo.getLabelBackgroundColor(),
-                homeTeamInfo.getLabelFontColor());
+                homeTeamInfo.getId(), homeTeamInfo.getAlias(), homeTeamInfo.getLabelFontColor());
     }
 }

--- a/application/src/main/java/org/depromeet/spot/application/team/CreateBaseballTeamController.java
+++ b/application/src/main/java/org/depromeet/spot/application/team/CreateBaseballTeamController.java
@@ -38,13 +38,13 @@ public class CreateBaseballTeamController {
             @RequestParam("logo") MultipartFile logo,
             @RequestParam("name") String name,
             @RequestParam("alias") String alias,
-            @RequestParam("labelBackgroundColor") String labelBackgroundColor) {
+            @RequestParam("labelFontColor") String labelFontColor) {
         CreateBaseballTeamCommand command =
                 CreateBaseballTeamCommand.builder()
                         .logo(logo)
                         .name(name)
                         .alias(alias)
-                        .labelBackgroundColor(labelBackgroundColor)
+                        .fontColor(labelFontColor)
                         .build();
         createBaseballTeamUsecase.save(command);
     }

--- a/domain/src/main/java/org/depromeet/spot/domain/section/Section.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/section/Section.java
@@ -1,7 +1,5 @@
 package org.depromeet.spot.domain.section;
 
-import org.depromeet.spot.domain.common.HexCode;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,5 +15,4 @@ public class Section {
     private final Long stadiumId;
     private final String name;
     private final String alias;
-    private final HexCode labelColor;
 }

--- a/domain/src/main/java/org/depromeet/spot/domain/team/BaseballTeam.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/team/BaseballTeam.java
@@ -16,19 +16,12 @@ public class BaseballTeam {
     private final String name;
     private final String alias;
     private final String logo;
-    private final HexCode labelBackgroundColor;
     private final HexCode labelFontColor;
 
     private static final int MAX_NAME_LENGTH = 20;
     private static final int MAX_ALIAS_LENGTH = 10;
 
-    public BaseballTeam(
-            Long id,
-            String name,
-            String alias,
-            String logo,
-            HexCode labelBackgroundColor,
-            HexCode labelFontColor) {
+    public BaseballTeam(Long id, String name, String alias, String logo, HexCode labelFontColor) {
         checkValidName(name);
         checkValidAlias(alias);
         checkValidLogo(logo);
@@ -37,7 +30,6 @@ public class BaseballTeam {
         this.name = name;
         this.alias = alias;
         this.logo = logo;
-        this.labelBackgroundColor = labelBackgroundColor;
         this.labelFontColor = labelFontColor;
     }
 

--- a/domain/src/test/java/org/depromeet/spot/domain/team/BaseballTeamTest.java
+++ b/domain/src/test/java/org/depromeet/spot/domain/team/BaseballTeamTest.java
@@ -17,7 +17,6 @@ class BaseballTeamTest {
     @NullAndEmptySource
     void name이_null_또는_blank일_때_BaseballTeam을_생성할_수_없다(String name) {
         // given
-        HexCode backgroundColor = new HexCode("#FFFFFF");
         HexCode fontColor = new HexCode("#FFFFFF");
 
         // when
@@ -27,12 +26,7 @@ class BaseballTeamTest {
                         assertThatThrownBy(
                                         () ->
                                                 new BaseballTeam(
-                                                        1L,
-                                                        name,
-                                                        "alias",
-                                                        "logo",
-                                                        backgroundColor,
-                                                        fontColor))
+                                                        1L, name, "alias", "logo", fontColor))
                                 .isInstanceOf(InvalidBaseballTeamNameException.class),
                 () ->
                         assertThatThrownBy(
@@ -48,16 +42,12 @@ class BaseballTeamTest {
     @Test
     void name_길이는_20글자를_초과할_수_없다() {
         // given
-        HexCode backgroundColor = new HexCode("#FFFFFF");
         HexCode fontColor = new HexCode("#FFFFFF");
         final String name = "012345678901234567890";
 
         // when
         // then
-        assertThatThrownBy(
-                        () ->
-                                new BaseballTeam(
-                                        1L, name, "alias", "logo", backgroundColor, fontColor))
+        assertThatThrownBy(() -> new BaseballTeam(1L, name, "alias", "logo", fontColor))
                 .isInstanceOf(InvalidBaseballTeamNameException.class);
     }
 
@@ -65,7 +55,6 @@ class BaseballTeamTest {
     @NullAndEmptySource
     void alias가_null_또는_blank일_때_BaseballTeam을_생성할_수_없다(String alias) {
         // given
-        HexCode backgroundColor = new HexCode("#FFFFFF");
         HexCode fontColor = new HexCode("#FFFFFF");
 
         // when
@@ -75,12 +64,7 @@ class BaseballTeamTest {
                         assertThatThrownBy(
                                         () ->
                                                 new BaseballTeam(
-                                                        1L,
-                                                        "name",
-                                                        alias,
-                                                        "logo",
-                                                        backgroundColor,
-                                                        fontColor))
+                                                        1L, "name", alias, "logo", fontColor))
                                 .isInstanceOf(InvalidBaseballAliasNameException.class),
                 () ->
                         assertThatThrownBy(
@@ -89,6 +73,7 @@ class BaseballTeamTest {
                                                         .name("name")
                                                         .alias(alias)
                                                         .logo("logo")
+                                                        .labelFontColor(fontColor)
                                                         .build())
                                 .isInstanceOf(InvalidBaseballAliasNameException.class));
     }
@@ -96,16 +81,12 @@ class BaseballTeamTest {
     @Test
     void alias_길이는_10글자를_초과할_수_없다() {
         // given
-        HexCode backgroundColor = new HexCode("#FFFFFF");
         HexCode fontColor = new HexCode("#FFFFFF");
         final String alias = "01234567890";
 
         // when
         // then
-        assertThatThrownBy(
-                        () ->
-                                new BaseballTeam(
-                                        1L, "name", alias, "logo", backgroundColor, fontColor))
+        assertThatThrownBy(() -> new BaseballTeam(1L, "name", alias, "logo", fontColor))
                 .isInstanceOf(InvalidBaseballAliasNameException.class);
     }
 
@@ -113,7 +94,6 @@ class BaseballTeamTest {
     @NullAndEmptySource
     void logo가_null_또는_blank일_때_BaseballTeam을_생성할_수_없다(String logo) {
         // given
-        HexCode backgroundColor = new HexCode("#FFFFFF");
         HexCode fontColor = new HexCode("#FFFFFF");
 
         // when
@@ -123,12 +103,7 @@ class BaseballTeamTest {
                         assertThatThrownBy(
                                         () ->
                                                 new BaseballTeam(
-                                                        1L,
-                                                        "name",
-                                                        "alias",
-                                                        logo,
-                                                        backgroundColor,
-                                                        fontColor))
+                                                        1L, "name", "alias", logo, fontColor))
                                 .isInstanceOf(EmptyTeamLogoException.class),
                 () ->
                         assertThatThrownBy(
@@ -137,6 +112,7 @@ class BaseballTeamTest {
                                                         .name("name")
                                                         .alias("alias")
                                                         .logo(logo)
+                                                        .labelFontColor(fontColor)
                                                         .build())
                                 .isInstanceOf(EmptyTeamLogoException.class));
     }

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/section/entity/SectionEntity.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/section/entity/SectionEntity.java
@@ -4,7 +4,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 
-import org.depromeet.spot.domain.common.HexCode;
 import org.depromeet.spot.domain.section.Section;
 import org.depromeet.spot.infrastructure.jpa.common.entity.BaseEntity;
 
@@ -26,15 +25,8 @@ public class SectionEntity extends BaseEntity {
     @Column(name = "alias", length = 20)
     private String alias;
 
-    @Column(name = "label_color", nullable = false)
-    private String labelColor;
-
     public static SectionEntity from(Section section) {
-        return new SectionEntity(
-                section.getStadiumId(),
-                section.getName(),
-                section.getAlias(),
-                section.getLabelColor().getValue());
+        return new SectionEntity(section.getStadiumId(), section.getName(), section.getAlias());
     }
 
     public static SectionEntity withSection(Section section) {
@@ -46,11 +38,9 @@ public class SectionEntity extends BaseEntity {
         stadiumId = section.getStadiumId();
         name = section.getName();
         alias = section.getAlias();
-        labelColor = section.getLabelColor().getValue();
     }
 
     public Section toDomain() {
-        HexCode labelHexColor = new HexCode(labelColor);
-        return new Section(this.getId(), stadiumId, name, alias, labelHexColor);
+        return new Section(this.getId(), stadiumId, name, alias);
     }
 }

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/section/repository/SectionJdbcRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/section/repository/SectionJdbcRepository.java
@@ -19,15 +19,13 @@ public class SectionJdbcRepository {
 
     public void createSections(List<Section> sections) {
         jdbcTemplate.batchUpdate(
-                "insert into sections"
-                        + "(stadium_id, name, alias, label_color) values (?, ?, ?, ?)",
+                "insert into sections" + "(stadium_id, name, alias) values (?, ?, ?)",
                 new BatchPreparedStatementSetter() {
                     @Override
                     public void setValues(PreparedStatement ps, int i) throws SQLException {
                         ps.setLong(1, sections.get(i).getStadiumId());
                         ps.setString(2, sections.get(i).getName());
                         ps.setString(3, sections.get(i).getAlias());
-                        ps.setString(4, sections.get(i).getLabelColor().getValue());
                     }
 
                     @Override

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/team/entity/BaseballTeamEntity.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/team/entity/BaseballTeamEntity.java
@@ -26,9 +26,6 @@ public class BaseballTeamEntity extends BaseEntity {
     @Column(name = "logo", nullable = false, length = 255)
     private String logo;
 
-    @Column(name = "label_background_color", nullable = false, unique = true, length = 10)
-    private String labelBackgroundColor;
-
     @Column(name = "label_font_color", nullable = false, length = 10)
     private String labelFontColor;
 
@@ -37,13 +34,11 @@ public class BaseballTeamEntity extends BaseEntity {
                 baseballTeam.getName(),
                 baseballTeam.getAlias(),
                 baseballTeam.getLogo(),
-                baseballTeam.getLabelBackgroundColor().getValue(),
                 baseballTeam.getLabelFontColor().getValue());
     }
 
     public BaseballTeam toDomain() {
-        HexCode backgroundColor = new HexCode(labelBackgroundColor);
         HexCode fontColor = new HexCode(labelFontColor);
-        return new BaseballTeam(this.getId(), name, alias, logo, backgroundColor, fontColor);
+        return new BaseballTeam(this.getId(), name, alias, logo, fontColor);
     }
 }

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/team/repository/BaseballTeamJdbcRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/team/repository/BaseballTeamJdbcRepository.java
@@ -20,14 +20,14 @@ public class BaseballTeamJdbcRepository {
     public void createBaseballTeams(List<BaseballTeam> teams) {
         jdbcTemplate.batchUpdate(
                 "insert into baseball_teams"
-                        + "(name, alias, logo, label_background_color) values (?, ?, ?, ?)",
+                        + "(name, alias, logo, label_font_color) values (?, ?, ?, ?)",
                 new BatchPreparedStatementSetter() {
                     @Override
                     public void setValues(PreparedStatement ps, int i) throws SQLException {
                         ps.setString(1, teams.get(i).getName());
                         ps.setString(2, teams.get(i).getAlias());
                         ps.setString(3, teams.get(i).getLogo());
-                        ps.setString(4, teams.get(i).getLabelBackgroundColor().getValue());
+                        ps.setString(4, teams.get(i).getLabelFontColor().getValue());
                     }
 
                     @Override

--- a/infrastructure/src/main/resources/data.sql
+++ b/infrastructure/src/main/resources/data.sql
@@ -9,10 +9,10 @@ VALUES (1, '잠실 야구 경기장', 'main_image_a.jpg', 'seating_chart_a.jpg',
         0);
 
 -- Baseball Teams
-INSERT INTO baseball_teams (id, name, alias, logo, label_background_color, label_font_color)
-VALUES (1, 'Team A', 'A', 'logo_a.png', '#1F1F52', '#FFFFFF'),
-       (2, 'Team B', 'B', 'logo_b.png', '#1E4D9C', '#FFFFFF'),
-       (3, 'Team C', 'C', 'logo_c.png', '#D72E34', '#FFFFFF');
+INSERT INTO baseball_teams (id, name, alias, logo, label_font_color)
+VALUES (1, 'Team A', 'A', 'logo_a.png', '#FFFFFF'),
+       (2, 'Team B', 'B', 'logo_b.png', '#FFFFFF'),
+       (3, 'Team C', 'C', 'logo_c.png', '#FFFFFF');
 
 -- Stadium Home Teams
 INSERT INTO stadium_home_teams (id, stadium_id, team_id)

--- a/infrastructure/src/main/resources/data.sql
+++ b/infrastructure/src/main/resources/data.sql
@@ -22,10 +22,10 @@ VALUES (1, 1, 1),
        (4, 1, 2);
 
 -- Stadium Sections
-INSERT INTO sections (id, stadium_id, name, alias, label_color)
-VALUES (1, 1, '오렌지석', '응원석', '#FFFFFF'),
-       (2, 1, '네이비석', '프리미엄석', '#B3B248'),
-       (3, 1, '레드석', null, '#CA53A9');
+INSERT INTO sections (id, stadium_id, name, alias)
+VALUES (1, 1, '오렌지석', '응원석'),
+       (2, 1, '네이비석', '프리미엄석'),
+       (3, 1, '레드석', null);
 
 -- Block
 INSERT INTO blocks (id, stadium_id, section_id, code, max_rows)

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/section/CreateSectionUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/section/CreateSectionUsecase.java
@@ -2,7 +2,6 @@ package org.depromeet.spot.usecase.port.in.section;
 
 import java.util.List;
 
-import org.depromeet.spot.domain.common.HexCode;
 import org.depromeet.spot.domain.section.Section;
 
 import lombok.Builder;
@@ -12,16 +11,10 @@ public interface CreateSectionUsecase {
     void createAll(Long stadiumId, List<CreateSectionCommand> commands);
 
     @Builder
-    record CreateSectionCommand(String name, String alias, String labelColor) {
+    record CreateSectionCommand(String name, String alias) {
 
         public Section toDomain(final Long stadiumId) {
-            HexCode hexCode = new HexCode(labelColor);
-            return Section.builder()
-                    .stadiumId(stadiumId)
-                    .name(name)
-                    .alias(alias)
-                    .labelColor(hexCode)
-                    .build();
+            return Section.builder().stadiumId(stadiumId).name(name).alias(alias).build();
         }
     }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/section/SectionReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/section/SectionReadUsecase.java
@@ -30,14 +30,12 @@ public interface SectionReadUsecase {
         private final Long id;
         private final String name;
         private final String alias;
-        private final String color;
 
         public static SectionInfo from(Section section) {
             return SectionInfo.builder()
                     .id(section.getId())
                     .name(section.getName())
                     .alias(section.getAlias())
-                    .color(section.getLabelColor().getValue())
                     .build();
         }
     }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/team/CreateBaseballTeamUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/team/CreateBaseballTeamUsecase.java
@@ -10,5 +10,5 @@ public interface CreateBaseballTeamUsecase {
 
     @Builder
     record CreateBaseballTeamCommand(
-            MultipartFile logo, String name, String alias, String labelBackgroundColor) {}
+            MultipartFile logo, String name, String alias, String fontColor) {}
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/team/ReadStadiumHomeTeamUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/team/ReadStadiumHomeTeamUsecase.java
@@ -20,7 +20,6 @@ public interface ReadStadiumHomeTeamUsecase {
     class HomeTeamInfo {
         private final Long id;
         private final String alias;
-        private final String labelBackgroundColor;
         private final String labelFontColor;
     }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/StadiumReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/StadiumReadService.java
@@ -44,8 +44,6 @@ public class StadiumReadService implements StadiumReadUsecase {
                                                                     new HomeTeamInfo(
                                                                             t.getId(),
                                                                             t.getAlias(),
-                                                                            t.getLabelBackgroundColor()
-                                                                                    .getValue(),
                                                                             t.getLabelFontColor()
                                                                                     .getValue()))
                                                     .toList();

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/team/CreateBaseballTeamService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/team/CreateBaseballTeamService.java
@@ -30,13 +30,13 @@ public class CreateBaseballTeamService implements CreateBaseballTeamUsecase {
         checkExistsName(name);
         final String logoUrl =
                 imageUploadPort.upload(name, command.logo(), MediaProperty.TEAM_LOGO);
-        HexCode backgroundColor = new HexCode(command.labelBackgroundColor());
+        HexCode fontColor = new HexCode(command.fontColor());
         BaseballTeam team =
                 BaseballTeam.builder()
                         .name(name)
                         .alias(command.alias())
                         .logo(logoUrl)
-                        .labelBackgroundColor(backgroundColor)
+                        .labelFontColor(fontColor)
                         .build();
         baseballTeamRepository.saveAll(List.of(team));
     }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/team/ReadStadiumHomeTeamService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/team/ReadStadiumHomeTeamService.java
@@ -26,10 +26,7 @@ public class ReadStadiumHomeTeamService implements ReadStadiumHomeTeamUsecase {
                 .map(
                         t ->
                                 new HomeTeamInfo(
-                                        t.getId(),
-                                        t.getAlias(),
-                                        t.getLabelBackgroundColor().getValue(),
-                                        t.getLabelFontColor().getValue()))
+                                        t.getId(), t.getAlias(), t.getLabelFontColor().getValue()))
                 .toList();
     }
 

--- a/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeBaseballTeamRepository.java
+++ b/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeBaseballTeamRepository.java
@@ -38,7 +38,7 @@ public class FakeBaseballTeamRepository implements BaseballTeamRepository {
                             .name(team.getName())
                             .alias(team.getAlias())
                             .logo(team.getLogo())
-                            .labelBackgroundColor(team.getLabelBackgroundColor())
+                            .labelFontColor(team.getLabelFontColor())
                             .build();
             data.add(newTeam);
             return newTeam;

--- a/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeSectionRepository.java
+++ b/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeSectionRepository.java
@@ -28,7 +28,6 @@ public class FakeSectionRepository implements SectionRepository {
                             .stadiumId(section.getStadiumId())
                             .name(section.getName())
                             .alias(section.getAlias())
-                            .labelColor(section.getLabelColor())
                             .build();
             data.add(newSection);
             return newSection;

--- a/usecase/src/test/java/org/depromeet/spot/usecase/service/section/SectionReadServiceTest.java
+++ b/usecase/src/test/java/org/depromeet/spot/usecase/service/section/SectionReadServiceTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.List;
 
 import org.depromeet.spot.common.exception.stadium.StadiumException.StadiumNotFoundException;
-import org.depromeet.spot.domain.common.HexCode;
 import org.depromeet.spot.domain.section.Section;
 import org.depromeet.spot.domain.stadium.Stadium;
 import org.depromeet.spot.usecase.port.in.section.SectionReadUsecase.SectionInfo;
@@ -53,22 +52,8 @@ public class SectionReadServiceTest {
                         .build();
         fakeStadiumRepository.save(stadium);
 
-        Section section1 =
-                Section.builder()
-                        .id(1L)
-                        .stadiumId(1L)
-                        .name("오렌지석")
-                        .alias("응원석")
-                        .labelColor(new HexCode("#FFFFFF"))
-                        .build();
-        Section section2 =
-                Section.builder()
-                        .id(2L)
-                        .stadiumId(1L)
-                        .name("레드석")
-                        .alias(null)
-                        .labelColor(new HexCode("#FFFFF1"))
-                        .build();
+        Section section1 = Section.builder().id(1L).stadiumId(1L).name("오렌지석").alias("응원석").build();
+        Section section2 = Section.builder().id(2L).stadiumId(1L).name("레드석").alias(null).build();
         fakeSectionRepository.save(section1);
         fakeSectionRepository.save(section2);
     }

--- a/usecase/src/test/java/org/depromeet/spot/usecase/service/team/CreateBaseballTeamServiceTest.java
+++ b/usecase/src/test/java/org/depromeet/spot/usecase/service/team/CreateBaseballTeamServiceTest.java
@@ -30,7 +30,7 @@ class CreateBaseballTeamServiceTest {
                         .name("두산 베어스")
                         .alias("두산")
                         .logo("logo1.png")
-                        .labelBackgroundColor(new HexCode("#FFFFFF"))
+                        .labelFontColor(new HexCode("#FFFFFF"))
                         .build();
         fakeBaseballTeamRepository.save(team);
     }

--- a/usecase/src/test/java/org/depromeet/spot/usecase/service/team/ReadBaseballTeamServiceTest.java
+++ b/usecase/src/test/java/org/depromeet/spot/usecase/service/team/ReadBaseballTeamServiceTest.java
@@ -29,7 +29,7 @@ class ReadBaseballTeamServiceTest {
                         .name("두산 베어스")
                         .alias("두산")
                         .logo("logo1.png")
-                        .labelBackgroundColor(new HexCode("#FFFFFF"))
+                        .labelFontColor(new HexCode("#FFFFFF"))
                         .build();
         BaseballTeam team2 =
                 BaseballTeam.builder()
@@ -37,7 +37,7 @@ class ReadBaseballTeamServiceTest {
                         .name("SSG 랜더스")
                         .alias("SSG")
                         .logo("logo2.png")
-                        .labelBackgroundColor(new HexCode("#FFFFF1"))
+                        .labelFontColor(new HexCode("#FFFFF1"))
                         .build();
 
         fakeBaseballTeamRepository.save(team1);


### PR DESCRIPTION
## 📌 개요 (필수)

- GUI 변경으로 구역 label, 홈팀 label 색상에 그라디언트 요소가 추가되었어요.
- 따라서 색상 관련 값을 AOS에서 관리하게 되었으므로, 관련 필드와 코드를 수정 & 삭제해요.
- 폰트 색상은 단색이라 서버에서 관리하는 것 유지!

<br>

## 🔨 작업 사항 (필수)

- section의 labelColor 삭제
- baseballTeam의 labelBackgroundColor 삭제
- 관련 테스트코드 수정
- 관련 usecase 코드 수정
- 관련 request, response 코드 수정
- data.sql 수정

<br>

## 🌱 연관 내용 (선택)

- AOS가 서버가 내려주는 색상 필드를 사용하는 코드를 수정하기 전까지는 merge되면 안되는 PR이에요.
- 리뷰만 미리 해주세요! 이후 AOS에게 핑 받으면 merge & DB table alter한 후 배포할게요~

<br>

## 💻 실행 화면 (필수)

> 로컬에서 table alter 후 실행했어요~

- 구역 조회 API
<img width="432" alt="스크린샷 2024-08-11 오후 10 35 11" src="https://github.com/user-attachments/assets/33716e40-0fee-49a9-a9e6-5a997f400e19">

- 구역 생성 API
<img width="555" alt="스크린샷 2024-08-11 오후 10 35 38" src="https://github.com/user-attachments/assets/1f62fe81-ff2b-46e7-b205-1d159cb57260">

- 홈 팀 조회 관련 API들
<img width="544" alt="스크린샷 2024-08-11 오후 10 34 33" src="https://github.com/user-attachments/assets/8f096ee0-b99d-4fa8-abc2-199a2f53a3d9">
<img width="466" alt="스크린샷 2024-08-11 오후 10 34 54" src="https://github.com/user-attachments/assets/5bc4f60a-293d-4034-9cfb-010dfd5a6100">

- 구단 생성 API (multipart 필요해서 swagger로..)
<img width="734" alt="스크린샷 2024-08-11 오후 10 37 55" src="https://github.com/user-attachments/assets/600aa435-4192-4358-af32-ee04ce427845">
