### PR TITLE
[NO_JIRA] loki 오류 fix

### DIFF
--- a/application/src/main/resources/appenders/console-appender.xml
+++ b/application/src/main/resources/appenders/console-appender.xml
@@ -11,4 +11,19 @@
         <minimumEventLevel>ERROR</minimumEventLevel>
     </appender>
 
+    <appender name="LOKI_APPENDER" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>http://${LOKI_URL}:3100/loki/api/v1/push</url>
+        </http>
+        <format>
+            <label>
+                <pattern>app=${name},host=${HOSTNAME},level=%level</pattern>
+                <readMarkers>true</readMarkers>
+            </label>
+            <message>
+                <pattern>%highlight([%-5level]) %d{yy-MM-dd HH:mm:ss.SSS} %green([%thread]) %yellow([traceId=%X{traceId}]) %cyan([%logger{0}:%line])-%message%n</pattern>
+            </message>
+            <sortByTime>true</sortByTime>
+        </format>
+    </appender>
 </included>

--- a/application/src/main/resources/logback-spring.xml
+++ b/application/src/main/resources/logback-spring.xml
@@ -1,16 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration scan="true" scanPeriod="5 seconds">
+    <appender name="LOKI_APPENDER" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>http://${LOKI_URL}:3100/loki/api/v1/push</url>
+        </http>
+        <format>
+            <label>
+                <pattern>app=${name},host=${HOSTNAME},level=%level</pattern>
+                <readMarkers>true</readMarkers>
+            </label>
+            <message>
+                <pattern>%highlight([%-5level]) %d{yy-MM-dd HH:mm:ss.SSS} %green([%thread]) %yellow([traceId=%X{traceId}]) %cyan([%logger{0}:%line])-%message%n</pattern>
+            </message>
+            <sortByTime>true</sortByTime>
+        </format>
+    </appender>
     <include resource="appenders/console-appender.xml"/>
-    <property name="loki.url" value="${LOKI_URL:-localhost}" />
     <springProfile name="local">
         <root level="INFO">
             <appender-ref ref="CONSOLE_APPENDER"/>
+            <appender-ref ref="LOKI_APPENDER"/>
         </root>
     </springProfile>
 
     <springProfile name="dev">
         <root level="INFO">
             <appender-ref ref="CONSOLE_APPENDER"/>
+            <appender-ref ref="LOKI_APPENDER"/>
         </root>
     </springProfile>
 
@@ -18,22 +34,7 @@
         <root level="ERROR">
             <appender-ref ref="CONSOLE_APPENDER"/>
             <appender-ref ref="SENTRY_APPENDER"/>
-
-            <appender name="LOKI_APPENDER" class="com.github.loki4j.logback.Loki4jAppender">
-                <http>
-                    <url>http://${loki.url}:3100/loki/api/v1/push</url>
-                </http>
-                <format>
-                    <label>
-                        <pattern>app=${name},host=${HOSTNAME},level=%level</pattern>
-                        <readMarkers>true</readMarkers>
-                    </label>
-                    <message>
-                        <pattern>%highlight([%-5level]) %d{yy-MM-dd HH:mm:ss.SSS} %green([%thread]) %yellow([traceId=%X{traceId}]) %cyan([%logger{0}:%line])-%message%n</pattern>
-                    </message>
-                    <sortByTime>true</sortByTime>
-                </format>
-            </appender>
+            <appender-ref ref="LOKI_APPENDER"/>
         </root>
     </springProfile>
 </configuration>

--- a/application/src/main/resources/logback-spring.xml
+++ b/application/src/main/resources/logback-spring.xml
@@ -1,20 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration scan="true" scanPeriod="5 seconds">
-    <appender name="LOKI_APPENDER" class="com.github.loki4j.logback.Loki4jAppender">
-        <http>
-            <url>http://${LOKI_URL}:3100/loki/api/v1/push</url>
-        </http>
-        <format>
-            <label>
-                <pattern>app=${name},host=${HOSTNAME},level=%level</pattern>
-                <readMarkers>true</readMarkers>
-            </label>
-            <message>
-                <pattern>%highlight([%-5level]) %d{yy-MM-dd HH:mm:ss.SSS} %green([%thread]) %yellow([traceId=%X{traceId}]) %cyan([%logger{0}:%line])-%message%n</pattern>
-            </message>
-            <sortByTime>true</sortByTime>
-        </format>
-    </appender>
     <include resource="appenders/console-appender.xml"/>
     <springProfile name="local">
         <root level="INFO">


### PR DESCRIPTION
## 📌 개요 (필수)

- Loki 오류 fix

<br>

## 🔨 작업 사항 (필수)

- loki appender 수정
  - 기존 appender 태그를 바로 쓴 방식이 문제가 있었던 것 같음. ([공식 문서](https://loki4j.github.io/loki-logback-appender/)에서도 configuration 하위에 appender 태그로 설정해준 후 appender-ref 태그로 사용하고 있었음.)
![image](https://github.com/user-attachments/assets/c390162e-c314-4cd6-a49d-0d2d2bcd3c00)

  - 문제 해결 후 console-append.xml 파일로 loki appender 설정 옮김
    - 기존에 안됐던 이유가 서버 인스턴스 3100번 포트가 막혀있어서 동작하지 않았던 것으로 예상하는 중...!

## 🌱 연관 내용 (선택)

- #133 

<br>

## 💻 실행 화면 (필수)

- 모니터링 인스턴스의 로키에서 정상적으로 로깅 완료
![image](https://github.com/user-attachments/assets/e1ba5971-0122-4b3d-ac61-8adc27a2c838)

