### PR TITLE
[BSVR-213] 리뷰 조회 API에 seat nullable 반영 & 기존 메서드의 N+1 수정

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/BaseReviewResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/BaseReviewResponse.java
@@ -30,7 +30,6 @@ public record BaseReviewResponse(
     public static BaseReviewResponse from(CreateReviewResult result) {
         Review review = result.review();
         Member member = result.member();
-        Seat seat = result.seat();
         return new BaseReviewResponse(
                 review.getId(),
                 MemberInfo.from(member),
@@ -38,7 +37,7 @@ public record BaseReviewResponse(
                 SectionResponse.from(review.getSection()),
                 BlockResponse.from(review.getBlock()),
                 RowResponse.from(review.getRow()),
-                SeatResponse.from(seat),
+                SeatResponse.from(result.seat()),
                 review.getDateTime(),
                 review.getContent(),
                 review.getImages().stream().map(ReviewImageResponse::from).toList(),
@@ -83,36 +82,43 @@ public record BaseReviewResponse(
     }
 
     public record StadiumResponse(Long id, String name) {
+
         public static StadiumResponse from(Stadium stadium) {
             return new StadiumResponse(stadium.getId(), stadium.getName());
         }
     }
 
     public record SectionResponse(Long id, String name, String alias) {
+
         public static SectionResponse from(Section section) {
             return new SectionResponse(section.getId(), section.getName(), section.getAlias());
         }
     }
 
     public record BlockResponse(Long id, String code) {
+
         public static BlockResponse from(Block block) {
             return new BlockResponse(block.getId(), block.getCode());
         }
     }
 
     public record RowResponse(Long id, Integer number) {
+
         public static RowResponse from(BlockRow row) {
             return new RowResponse(row.getId(), row.getNumber());
         }
     }
 
     public record SeatResponse(Long id, Integer seatNumber) {
+
         public static SeatResponse from(Seat seat) {
+            if (seat == null) return null;
             return new SeatResponse(seat.getId(), seat.getSeatNumber());
         }
     }
 
     public record MemberInfo(String profileImage, String nickname, Integer level) {
+
         public static MemberInfo from(Member member) {
             return new MemberInfo(
                     member.getProfileImage(), member.getNickname(), member.getLevel().getValue());

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/BlockReviewListResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/BlockReviewListResponse.java
@@ -1,7 +1,6 @@
 package org.depromeet.spot.application.review.dto.response;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.depromeet.spot.domain.review.image.TopReviewImage;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.BlockKeywordInfo;
@@ -29,19 +28,13 @@ public record BlockReviewListResponse(
             Integer month) {
 
         List<BaseReviewResponse> reviewResponses =
-                result.reviews().stream()
-                        .map(BaseReviewResponse::from)
-                        .collect(Collectors.toList());
+                result.reviews().stream().map(BaseReviewResponse::from).toList();
 
         List<KeywordCountResponse> keywordResponses =
-                result.topKeywords().stream()
-                        .map(KeywordCountResponse::from)
-                        .collect(Collectors.toList());
+                result.topKeywords().stream().map(KeywordCountResponse::from).toList();
 
         List<TopReviewImageResponse> topReviewImageResponses =
-                result.topReviewImages().stream()
-                        .map(TopReviewImageResponse::from)
-                        .collect(Collectors.toList());
+                result.topReviewImages().stream().map(TopReviewImageResponse::from).toList();
 
         FilterInfo filter = new FilterInfo(rowNumber, seatNumber, year, month);
 
@@ -63,6 +56,7 @@ public record BlockReviewListResponse(
     }
 
     public record KeywordCountResponse(String content, Long count, Boolean isPositive) {
+
         public static KeywordCountResponse from(BlockKeywordInfo info) {
             return new KeywordCountResponse(info.content(), info.count(), info.isPositive());
         }
@@ -70,6 +64,7 @@ public record BlockReviewListResponse(
 
     public record TopReviewImageResponse(
             String url, Long reviewId, String blockCode, Integer rowNumber, Integer seatNumber) {
+
         public static TopReviewImageResponse from(TopReviewImage image) {
             return new TopReviewImageResponse(
                     image.getUrl(),

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/entity/ReviewEntity.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/entity/ReviewEntity.java
@@ -133,7 +133,7 @@ public class ReviewEntity extends BaseEntity {
                         .section(this.section.toDomain())
                         .block(this.block.toDomain())
                         .row(this.row.toDomain())
-                        .seat(this.seat.toDomain())
+                        .seat((this.seat == null) ? null : this.seat.toDomain())
                         .dateTime(this.dateTime)
                         .content(this.content)
                         .build();

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewCustomRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewCustomRepository.java
@@ -12,6 +12,7 @@ import static org.depromeet.spot.infrastructure.jpa.stadium.entity.QStadiumEntit
 
 import java.util.List;
 
+import org.depromeet.spot.infrastructure.jpa.block.entity.QBlockRowEntity;
 import org.depromeet.spot.infrastructure.jpa.review.entity.ReviewEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -40,6 +41,7 @@ public class ReviewCustomRepository {
             Pageable pageable) {
         BooleanBuilder builder =
                 buildConditions(stadiumId, blockCode, rowNumber, seatNumber, year, month);
+        QBlockRowEntity rowEntity = new QBlockRowEntity("br");
         List<ReviewEntity> results =
                 queryFactory
                         .selectFrom(reviewEntity)
@@ -52,6 +54,8 @@ public class ReviewCustomRepository {
                         .leftJoin(reviewEntity.row, blockRowEntity)
                         .fetchJoin()
                         .leftJoin(reviewEntity.seat, seatEntity)
+                        .fetchJoin()
+                        .leftJoin(seatEntity.row, rowEntity)
                         .fetchJoin()
                         .leftJoin(reviewEntity.keywords, reviewKeywordEntity)
                         .fetchJoin()

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewCustomRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewCustomRepository.java
@@ -1,0 +1,111 @@
+package org.depromeet.spot.infrastructure.jpa.review.repository;
+
+import static org.depromeet.spot.infrastructure.jpa.block.entity.QBlockEntity.blockEntity;
+import static org.depromeet.spot.infrastructure.jpa.block.entity.QBlockRowEntity.blockRowEntity;
+import static org.depromeet.spot.infrastructure.jpa.review.entity.QReviewEntity.reviewEntity;
+import static org.depromeet.spot.infrastructure.jpa.seat.entity.QSeatEntity.seatEntity;
+import static org.depromeet.spot.infrastructure.jpa.section.entity.QSectionEntity.sectionEntity;
+import static org.depromeet.spot.infrastructure.jpa.stadium.entity.QStadiumEntity.stadiumEntity;
+
+import java.util.List;
+
+import org.depromeet.spot.infrastructure.jpa.review.entity.ReviewEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Page<ReviewEntity> findByStadiumIdAndBlockCode(
+            Long stadiumId,
+            String blockCode,
+            Integer rowNumber,
+            Integer seatNumber,
+            Integer year,
+            Integer month,
+            Pageable pageable) {
+        BooleanBuilder builder =
+                buildConditions(stadiumId, blockCode, rowNumber, seatNumber, year, month);
+        List<ReviewEntity> results =
+                queryFactory
+                        .selectFrom(reviewEntity)
+                        .leftJoin(reviewEntity.stadium, stadiumEntity)
+                        .fetchJoin()
+                        .leftJoin(reviewEntity.section, sectionEntity)
+                        .fetchJoin()
+                        .leftJoin(reviewEntity.block, blockEntity)
+                        .fetchJoin()
+                        .leftJoin(reviewEntity.row, blockRowEntity)
+                        .fetchJoin()
+                        .leftJoin(reviewEntity.seat, seatEntity)
+                        .fetchJoin()
+                        .where(builder)
+                        .orderBy(reviewEntity.dateTime.desc())
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch();
+
+        long total = queryFactory.selectFrom(reviewEntity).where(builder).fetch().size();
+
+        return new PageImpl<>(results, pageable, total);
+    }
+
+    private BooleanBuilder buildConditions(
+            Long stadiumId,
+            String blockCode,
+            Integer rowNumber,
+            Integer seatNumber,
+            Integer year,
+            Integer month) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(reviewEntity.stadium.id.eq(stadiumId));
+        builder.and(reviewEntity.block.code.eq(blockCode));
+        builder.and(eqRowNumber(rowNumber));
+        builder.and(eqSeatNumber(seatNumber));
+        builder.and(eqYear(year));
+        builder.and(eqMonth(month));
+        builder.and(reviewEntity.deletedAt.isNull());
+
+        return builder;
+    }
+
+    private BooleanExpression eqRowNumber(Integer rowNumber) {
+        if (rowNumber != null) {
+            return reviewEntity.row.number.eq(rowNumber);
+        }
+        return null;
+    }
+
+    private BooleanExpression eqSeatNumber(Integer seatNumber) {
+        if (seatNumber != null) {
+            return reviewEntity.seat.seatNumber.eq(seatNumber);
+        }
+        return null;
+    }
+
+    private BooleanExpression eqYear(Integer year) {
+        if (year != null) {
+            return reviewEntity.dateTime.year().eq(year);
+        }
+        return null;
+    }
+
+    private BooleanExpression eqMonth(Integer month) {
+        if (month != null) {
+            return reviewEntity.dateTime.month().eq(month);
+        }
+        return null;
+    }
+}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewCustomRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewCustomRepository.java
@@ -2,7 +2,10 @@ package org.depromeet.spot.infrastructure.jpa.review.repository;
 
 import static org.depromeet.spot.infrastructure.jpa.block.entity.QBlockEntity.blockEntity;
 import static org.depromeet.spot.infrastructure.jpa.block.entity.QBlockRowEntity.blockRowEntity;
+import static org.depromeet.spot.infrastructure.jpa.member.entity.QLevelEntity.levelEntity;
+import static org.depromeet.spot.infrastructure.jpa.member.entity.QMemberEntity.memberEntity;
 import static org.depromeet.spot.infrastructure.jpa.review.entity.QReviewEntity.reviewEntity;
+import static org.depromeet.spot.infrastructure.jpa.review.entity.keyword.QReviewKeywordEntity.reviewKeywordEntity;
 import static org.depromeet.spot.infrastructure.jpa.seat.entity.QSeatEntity.seatEntity;
 import static org.depromeet.spot.infrastructure.jpa.section.entity.QSectionEntity.sectionEntity;
 import static org.depromeet.spot.infrastructure.jpa.stadium.entity.QStadiumEntity.stadiumEntity;
@@ -49,6 +52,12 @@ public class ReviewCustomRepository {
                         .leftJoin(reviewEntity.row, blockRowEntity)
                         .fetchJoin()
                         .leftJoin(reviewEntity.seat, seatEntity)
+                        .fetchJoin()
+                        .leftJoin(reviewEntity.keywords, reviewKeywordEntity)
+                        .fetchJoin()
+                        .leftJoin(reviewEntity.member, memberEntity)
+                        .fetchJoin()
+                        .leftJoin(memberEntity.level, levelEntity)
                         .fetchJoin()
                         .where(builder)
                         .orderBy(reviewEntity.dateTime.desc())

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewJpaRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewJpaRepository.java
@@ -17,22 +17,6 @@ public interface ReviewJpaRepository extends JpaRepository<ReviewEntity, Long> {
     long countByMemberIdAndDeletedAtIsNull(Long memberId);
 
     @Query(
-            "SELECT r FROM ReviewEntity r WHERE r.stadium.id = :stadiumId AND r.block.code = :blockCode "
-                    + "AND (:rowNumber IS NULL OR r.row.number = :rowNumber) "
-                    + "AND (:seatNumber IS NULL OR r.seat.seatNumber = :seatNumber) "
-                    + "AND (:year IS NULL OR YEAR(r.dateTime) = :year) "
-                    + "AND (:month IS NULL OR MONTH(r.dateTime) = :month) "
-                    + "AND r.deletedAt IS NULL")
-    Page<ReviewEntity> findByStadiumIdAndBlockCode(
-            @Param("stadiumId") Long stadiumId,
-            @Param("blockCode") String blockCode,
-            @Param("rowNumber") Integer rowNumber,
-            @Param("seatNumber") Integer seatNumber,
-            @Param("year") Integer year,
-            @Param("month") Integer month,
-            Pageable pageable);
-
-    @Query(
             "SELECT r FROM ReviewEntity r WHERE r.member.id = :userId "
                     + "AND (:year IS NULL OR YEAR(r.dateTime) = :year) "
                     + "AND (:month IS NULL OR MONTH(r.dateTime) = :month) "

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewRepositoryImpl.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewRepositoryImpl.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ReviewRepositoryImpl implements ReviewRepository {
 
     private final ReviewJpaRepository reviewJpaRepository;
+    private final ReviewCustomRepository reviewCustomRepository;
 
     @Override
     public Review save(Review review) {
@@ -50,7 +51,7 @@ public class ReviewRepositoryImpl implements ReviewRepository {
             Integer month,
             Pageable pageable) {
         Page<ReviewEntity> reviewEntities =
-                reviewJpaRepository.findByStadiumIdAndBlockCode(
+                reviewCustomRepository.findByStadiumIdAndBlockCode(
                         stadiumId, blockCode, rowNumber, seatNumber, year, month, pageable);
         return reviewEntities.map(ReviewEntity::toDomain);
     }

--- a/infrastructure/src/main/resources/application-jpa.yaml
+++ b/infrastructure/src/main/resources/application-jpa.yaml
@@ -2,7 +2,7 @@ spring:
     datasource:
         url: jdbc:mysql://localhost:3306/spot
         username: test1234
-        password: test1234
+        password: test1234!
         driver-class-name: com.mysql.cj.jdbc.Driver
 
     jpa:
@@ -13,6 +13,7 @@ spring:
         properties:
             hibernate:
                 use_sql_comments: true
+                default_batch_fetch_size: 1000
         defer-datasource-initialization: true
     sql:
         init:

--- a/infrastructure/src/main/resources/application-jpa.yaml
+++ b/infrastructure/src/main/resources/application-jpa.yaml
@@ -2,7 +2,7 @@ spring:
     datasource:
         url: jdbc:mysql://localhost:3306/spot
         username: test1234
-        password: test1234!
+        password: test1234
         driver-class-name: com.mysql.cj.jdbc.Driver
 
     jpa:
@@ -13,7 +13,6 @@ spring:
         properties:
             hibernate:
                 use_sql_comments: true
-                default_batch_fetch_size: 1000
         defer-datasource-initialization: true
     sql:
         init:


### PR DESCRIPTION
## 📌 개요 (필수)

- 리뷰에서 좌석 번호가 선택값으로 바뀜에 따라, 리뷰 조회 API에서 seat를 nullable 하게 바꿔요.

<br>

## 🔨 작업 사항 (필수)

- 리뷰 조회 관련 API res에서 seat nullable하게 수정
- (성능 개선) 블록별 리뷰 조회 메서드에서 리뷰 조회할 때 N+1 발생하는 것 수정

<br>

## 🌱 연관 내용 (선택)

- AOS 작업 완료 후 merge & 배포 예정
- 리뷰 조회 부분이 원래 제 담당이 아니라.. 로컬에서 동작하는걸 확인하긴 했지만, 좀 불안하네요ㅋㅋㅠ
  - 실제로 블록별 리뷰 조회는 seat_id = null 인 경우는 기존 쿼리가 처리해주지 못해서 쿼리를 수정했어요!
  - 혹시 논리 오류가 발생하진 않는지 한 번씩 크로스체크 해주면 좋을 것 같아요! @pminsung12 @wjdwnsdnjs13 

<br>

## 💻 실행 화면 (필수)

- 특정 리뷰 조회 API
<img width="358" alt="스크린샷 2024-08-16 오전 12 00 41" src="https://github.com/user-attachments/assets/033f5dcc-9b67-4f2e-a44c-48c1d09c6ff6">

- 내가 쓴 리뷰 조회 API
<img width="524" alt="스크린샷 2024-08-16 오전 12 01 12" src="https://github.com/user-attachments/assets/c3138f8f-90d2-4d09-a4cd-54ea5e3ccdb6">

- 내가 마지막으로 쓴 리뷰 조회 API
<img width="340" alt="스크린샷 2024-08-16 오전 12 02 07" src="https://github.com/user-attachments/assets/eb4a53b0-5dbf-4c03-a9fd-930a7508e6aa">

- 블록별 리뷰 조회 API (seat == null인 경우 / null 아닌 경우 각각 테스트 완료)
<img width="476" alt="스크린샷 2024-08-16 오전 1 05 29" src="https://github.com/user-attachments/assets/2081eccb-6315-4ec1-8b71-52839854d9b5">

<img width="460" alt="스크린샷 2024-08-16 오전 1 06 14" src="https://github.com/user-attachments/assets/315b401c-ca06-4d6a-a20d-b63988f64ffd">
