### PR TITLE
[NO_JIRA] 어드민 리뷰 등록시 키워드, 이미지 등록 로직 순서 변경

### DIFF
--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/CreateReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/CreateReviewService.java
@@ -87,13 +87,12 @@ public class CreateReviewService implements CreateReviewUsecase {
         Seat seat = getSeat(block.getId(), command.seatNumber());
 
         Review review = convertToDomain(member, blockRow, seat, command);
-        Review savedReview = reviewRepository.save(review);
-
         List<String> imageUrls = reviewImageProcessor.getImageUrl(command.images());
-        reviewImageProcessor.processImages(review, imageUrls);
-
         Map<Long, Keyword> keywordMap =
                 reviewKeywordProcessor.processKeywords(review, command.good(), command.bad());
+        reviewImageProcessor.processImages(review, imageUrls);
+
+        Review savedReview = reviewRepository.save(review);
         reviewKeywordProcessor.updateBlockTopKeywords(savedReview);
         savedReview.setKeywordMap(keywordMap);
 


### PR DESCRIPTION
## 📌 개요 (필수)

- 기존 코드에서 키워드, 이미지 관련 작업을 묶어서 처리하게 리팩토링했더니 이슈 발생
  - 리뷰는 정상적으로 등록되는데, 키워드/이미지가 등록되지 않음
  - 리팩토링 과정에서 메서드 순서를 바꾼 것이 원인으로 확인 -> 원복

<br>

## 🔨 작업 사항 (필수)

- 어드민 리뷰 등록 과정에서 이미지, 키워드 처리 로직의 순서 변경

<br>

## 💻 실행 화면 (필수)

- 로컬 실행 화면
<img width="815" alt="스크린샷 2024-08-16 오후 8 41 59" src="https://github.com/user-attachments/assets/96415a11-60a7-4ca3-8211-cf1099822b84">
<img width="993" alt="스크린샷 2024-08-16 오후 8 42 15" src="https://github.com/user-attachments/assets/fa7a7ab6-c310-49e1-8bfe-ded9bc81cc82">



