### PR TITLE
[BSVR-212] AWS ElastiCache Redis 세팅

### DIFF
--- a/.github/workflows/dev-build-and-deploy.yaml
+++ b/.github/workflows/dev-build-and-deploy.yaml
@@ -1,134 +1,136 @@
 name: Build And Test
 
 on:
-  push:
-    branches:
-      - main
-      - dev
-  pull_request:
-    branches:
-      - main
-      - dev
+    push:
+        branches:
+            - main
+            - dev
+    pull_request:
+        branches:
+            - main
+            - dev
 
 jobs:
-  build-and-test:
-    runs-on: ubuntu-latest
+    build-and-test:
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v4
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: "17"
-          distribution: "corretto"
+            -   name: Set up JDK 17
+                uses: actions/setup-java@v4
+                with:
+                    java-version: "17"
+                    distribution: "corretto"
 
-      - name: Cache Gradle
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+            -   name: Cache Gradle
+                uses: actions/cache@v3
+                with:
+                    path: |
+                        ~/.gradle/caches
+                        ~/.gradle/wrapper
+                    key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+                    restore-keys: |
+                        ${{ runner.os }}-gradle-
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+            -   name: Grant execute permission for gradlew
+                run: chmod +x gradlew
 
-      - name: Build with Gradle
-        run: ./gradlew build -x test --stacktrace --parallel
+            -   name: Build with Gradle
+                run: ./gradlew build -x test --stacktrace --parallel
 
-      - name: Run tests
-        run: ./gradlew test
+            -   name: Run tests
+                run: ./gradlew test
 
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
-        with:
-          files: '**/build/test-results/test/TEST-*.xml'
+            -   name: Publish Unit Test Results
+                uses: EnricoMi/publish-unit-test-result-action@v2
+                if: always()
+                with:
+                    files: '**/build/test-results/test/TEST-*.xml'
 
-      - name: JUnit Report Action
-        uses: mikepenz/action-junit-report@v3
-        if: always()
-        with:
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+            -   name: JUnit Report Action
+                uses: mikepenz/action-junit-report@v3
+                if: always()
+                with:
+                    report_paths: '**/build/test-results/test/TEST-*.xml'
 
-      - name: Store test results
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: test-results
-          path: '**/build/test-results/test/TEST-*.xml'
+            -   name: Store test results
+                uses: actions/upload-artifact@v3
+                if: always()
+                with:
+                    name: test-results
+                    path: '**/build/test-results/test/TEST-*.xml'
 
-      - name: Test Report Summary
-        if: always()
-        run: |
-          echo '## Test Report Summary' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          ./gradlew test --console=plain || true
-          echo '```' >> $GITHUB_STEP_SUMMARY
+            -   name: Test Report Summary
+                if: always()
+                run: |
+                    echo '## Test Report Summary' >> $GITHUB_STEP_SUMMARY
+                    echo '```' >> $GITHUB_STEP_SUMMARY
+                    ./gradlew test --console=plain || true
+                    echo '```' >> $GITHUB_STEP_SUMMARY
 
-  deploy:
-      needs: build-and-test
-      if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push'
-      runs-on: ubuntu-latest
+    deploy:
+        needs: build-and-test
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push'
+        runs-on: ubuntu-latest
 
-      steps:
-          -   name: Checkout code
-              uses: actions/checkout@v4
+        steps:
+            -   name: Checkout code
+                uses: actions/checkout@v4
 
-          -   name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v2
+            -   name: Set up Docker Buildx
+                uses: docker/setup-buildx-action@v2
 
-          -   name: Login to DockerHub
-              uses: docker/login-action@v2
-              with:
-                  username: ${{ secrets.DOCKERHUB_USERNAME }}
-                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+            -   name: Login to DockerHub
+                uses: docker/login-action@v2
+                with:
+                    username: ${{ secrets.DOCKERHUB_USERNAME }}
+                    password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-          -   name: Build and push Docker image
-              uses: docker/build-push-action@v4
-              with:
-                  context: .
-                  push: true
-                  tags: ${{ secrets.DOCKERHUB_USERNAME }}/spot-server:dev-${{ github.sha }}
+            -   name: Build and push Docker image
+                uses: docker/build-push-action@v4
+                with:
+                    context: .
+                    push: true
+                    tags: ${{ secrets.DOCKERHUB_USERNAME }}/spot-server:dev-${{ github.sha }}
 
-          - name: Deploy to Dev NCP Server
-            uses: appleboy/ssh-action@master
-            with:
-                host: ${{ secrets.DEV_SERVER_HOST }}
-                username: ${{ secrets.DEV_SERVER_USERNAME }}
-                password: ${{ secrets.DEV_SERVER_PASSWORD }}
-                port: ${{ secrets.DEV_SERVER_PORT }}
-                script: |
-                    docker pull ${{ secrets.DOCKERHUB_USERNAME }}/spot-server:dev-${{ github.sha }}
-                    docker stop spot-server-dev || true
-                    docker rm spot-server-dev || true
-                    docker run -d --name spot-server-dev \
-                      -p 8080:8080 \
-                      -p 9292:9292 \
-                      -p 3100:3100 \
-                      -e SPRING_PROFILES_ACTIVE=dev \
-                      -e SPRING_DATASOURCE_URL=${{ secrets.DEV_DB_URL }} \
-                      -e SPRING_DATASOURCE_USERNAME=${{ secrets.DEV_DB_USERNAME }} \
-                      -e SPRING_DATASOURCE_PASSWORD=${{ secrets.DEV_DB_PASSWORD }} \
-                      -e SPRING_JWT_SECRET=${{ secrets.JWT_SECRET }} \
-                      -e OAUTH_CLIENTID=${{ secrets.KAKAO_CLIENT_ID }} \
-                      -e OAUTH_KAUTHTOKENURLHOST=${{ secrets.KAUTH_TOKEN_URL_HOST }} \
-                      -e OAUTH_KAUTHUSERURLHOST=${{ secrets.KAUTH_USER_URL_HOST }} \
-                      -e SPRING_JPA_HIBERNATE_DDL_AUTO=validate \
-                      -e AWS_S3_ACCESS_KEY=${{ secrets.AWS_S3_ACCESS_KEY }} \
-                      -e AWS_S3_SECRET_KEY=${{ secrets.AWS_S3_SECRET_KEY }} \
-                      -e AWS_S3_BUCKET_NAME=${{ secrets.DEV_AWS_S3_BUCKET_NAME }} \
-                      -e TZ=Asia/Seoul \
-                      -e SENTRY_DSN=${{ secrets.SENTRY_DSN }} \
-                      -e SENTRY_ENABLE_TRACING=true \
-                      -e SENTRY_ENVIRONMENT=prod \
-                      -e LOKI_URL=${{ secrets.LOKI_SERVER_URL }} \
-                      ${{ secrets.DOCKERHUB_USERNAME }}/spot-server:dev-${{ github.sha }}
-                    docker system prune -af
+            -   name: Deploy to Dev NCP Server
+                uses: appleboy/ssh-action@master
+                with:
+                    host: ${{ secrets.DEV_SERVER_HOST }}
+                    username: ${{ secrets.DEV_SERVER_USERNAME }}
+                    password: ${{ secrets.DEV_SERVER_PASSWORD }}
+                    port: ${{ secrets.DEV_SERVER_PORT }}
+                    script: |
+                        docker pull ${{ secrets.DOCKERHUB_USERNAME }}/spot-server:dev-${{ github.sha }}
+                        docker stop spot-server-dev || true
+                        docker rm spot-server-dev || true
+                        docker run -d --name spot-server-dev \
+                          -p 8080:8080 \
+                          -p 9292:9292 \
+                          -p 3100:3100 \
+                          -e SPRING_PROFILES_ACTIVE=dev \
+                              -e AWS_REDIS_HOST=${{ secrets.DEV_REDIS_HOST }} \
+                              -e AWS_REDIS_PORT=${{ secrets.DEV_REDIS_PORT }}  \
+                          -e SPRING_DATASOURCE_URL=${{ secrets.DEV_DB_URL }} \
+                          -e SPRING_DATASOURCE_USERNAME=${{ secrets.DEV_DB_USERNAME }} \
+                          -e SPRING_DATASOURCE_PASSWORD=${{ secrets.DEV_DB_PASSWORD }} \
+                          -e SPRING_JWT_SECRET=${{ secrets.JWT_SECRET }} \
+                          -e OAUTH_CLIENTID=${{ secrets.KAKAO_CLIENT_ID }} \
+                          -e OAUTH_KAUTHTOKENURLHOST=${{ secrets.KAUTH_TOKEN_URL_HOST }} \
+                          -e OAUTH_KAUTHUSERURLHOST=${{ secrets.KAUTH_USER_URL_HOST }} \
+                          -e SPRING_JPA_HIBERNATE_DDL_AUTO=validate \
+                          -e AWS_S3_ACCESS_KEY=${{ secrets.AWS_S3_ACCESS_KEY }} \
+                          -e AWS_S3_SECRET_KEY=${{ secrets.AWS_S3_SECRET_KEY }} \
+                          -e AWS_S3_BUCKET_NAME=${{ secrets.DEV_AWS_S3_BUCKET_NAME }} \
+                          -e TZ=Asia/Seoul \
+                          -e SENTRY_DSN=${{ secrets.SENTRY_DSN }} \
+                          -e SENTRY_ENABLE_TRACING=true \
+                          -e SENTRY_ENVIRONMENT=prod \
+                          -e LOKI_URL=${{ secrets.LOKI_SERVER_URL }} \
+                          ${{ secrets.DOCKERHUB_USERNAME }}/spot-server:dev-${{ github.sha }}
+                        docker system prune -af
 
 #  create-release:
 #      needs: [ build-and-test, deploy ]  # deploy job이 성공적으로 완료된 후에만 실행

--- a/.github/workflows/manual-prod-deploy.yaml
+++ b/.github/workflows/manual-prod-deploy.yaml
@@ -48,6 +48,8 @@ jobs:
                           -p 9292:9292 \
                           -p 3100:3100 \
                           -e SPRING_PROFILES_ACTIVE=prod \
+                          -e AWS_REDIS_HOST=${{ secrets.PROD_REDIS_HOST }} \
+                          -e AWS_REDIS_PORT=${{ secrets.PROD_REDIS_PORT }}  \
                           -e SPRING_DATASOURCE_URL=${{ secrets.PROD_DB_URL }} \
                           -e SPRING_DATASOURCE_USERNAME=${{ secrets.PROD_DB_USERNAME }} \
                           -e SPRING_DATASOURCE_PASSWORD=${{ secrets.PROD_DB_PASSWORD }} \

--- a/application/src/main/java/org/depromeet/spot/application/common/config/SpotApplicationConfig.java
+++ b/application/src/main/java/org/depromeet/spot/application/common/config/SpotApplicationConfig.java
@@ -1,8 +1,6 @@
 package org.depromeet.spot.application.common.config;
 
-import org.depromeet.spot.infrastructure.aws.AwsConfig;
-import org.depromeet.spot.infrastructure.cache.config.CacheConfig;
-import org.depromeet.spot.infrastructure.jpa.config.JpaConfig;
+import org.depromeet.spot.infrastructure.InfrastructureConfig;
 import org.depromeet.spot.usecase.config.UsecaseConfig;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -10,12 +8,5 @@ import org.springframework.context.annotation.Import;
 
 @ComponentScan(basePackages = {"org.depromeet.spot.application"})
 @Configuration
-@Import(
-        value = {
-            UsecaseConfig.class,
-            JpaConfig.class,
-            AwsConfig.class,
-            CacheConfig.class,
-            SwaggerConfig.class
-        })
+@Import(value = {UsecaseConfig.class, SwaggerConfig.class, InfrastructureConfig.class})
 public class SpotApplicationConfig {}

--- a/infrastructure/build.gradle.kts
+++ b/infrastructure/build.gradle.kts
@@ -23,7 +23,10 @@ dependencies {
 
     // aws
     implementation("org.springframework.cloud:spring-cloud-starter-aws:_")
+
+    // redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis:_")
+    implementation("org.redisson:redisson-spring-boot-starter:_")
 
     // webflux (HTTP 요청에 사용)
     implementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/infrastructure/build.gradle.kts
+++ b/infrastructure/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
 
     // aws
     implementation("org.springframework.cloud:spring-cloud-starter-aws:_")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis:_")
 
     // webflux (HTTP 요청에 사용)
     implementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/InfrastructureConfig.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/InfrastructureConfig.java
@@ -1,0 +1,10 @@
+package org.depromeet.spot.infrastructure;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.ComponentScan;
+
+@EnableConfigurationProperties
+@ConfigurationPropertiesScan(basePackages = {"org.depromeet.spot.infrastructure"})
+@ComponentScan(basePackages = {"org.depromeet.spot.infrastructure"})
+public class InfrastructureConfig {}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/redis/RedisConfig.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/redis/RedisConfig.java
@@ -1,6 +1,30 @@
 package org.depromeet.spot.infrastructure.redis;
 
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import lombok.RequiredArgsConstructor;
+
 @Configuration
-public class RedisConfig {}
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config redissonConfig = new Config();
+        redissonConfig
+                .useSingleServer()
+                .setAddress(
+                        REDISSON_HOST_PREFIX
+                                + redisProperties.host()
+                                + ":"
+                                + redisProperties.port());
+        return Redisson.create(redissonConfig);
+    }
+}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/redis/RedisConfig.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/redis/RedisConfig.java
@@ -1,0 +1,6 @@
+package org.depromeet.spot.infrastructure.redis;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisConfig {}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/redis/RedisProperties.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/redis/RedisProperties.java
@@ -3,4 +3,7 @@ package org.depromeet.spot.infrastructure.redis;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "aws.redis")
-public class RedisProperties {}
+public class RedisProperties {
+    private String host;
+    private int port;
+}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/redis/RedisProperties.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/redis/RedisProperties.java
@@ -1,0 +1,6 @@
+package org.depromeet.spot.infrastructure.redis;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "aws.redis")
+public class RedisProperties {}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/redis/RedisProperties.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/redis/RedisProperties.java
@@ -3,7 +3,4 @@ package org.depromeet.spot.infrastructure.redis;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "aws.redis")
-public class RedisProperties {
-    private String host;
-    private int port;
-}
+public record RedisProperties(String host, int port) {}

--- a/versions.properties
+++ b/versions.properties
@@ -21,6 +21,8 @@ version.junit=5.9.1
 
 version.org.projectlombok..lombok=1.18.30
 
+version.org.redisson..redisson-spring-boot-starter=3.34.1
+
 version.org.springframework.boot..spring-boot-starter-test=3.0.1
 
 version.org.springframework.boot..spring-boot-starter-data-jpa=3.0.1
@@ -36,6 +38,8 @@ version.com.querydsl..querydsl-jpa=5.0.0
 version.org.springframework.cloud..spring-cloud-starter-aws=2.2.6.RELEASE
 
 version.org.springframework.boot..spring-boot-starter-data-redis=3.3.0
+
+version.org.redission..redisson-spring-boot-starter=3.26.0
 
 version.org.springframework.boot..spring-boot-configuration-processor=3.0.1
 

--- a/versions.properties
+++ b/versions.properties
@@ -35,6 +35,8 @@ version.com.querydsl..querydsl-jpa=5.0.0
 
 version.org.springframework.cloud..spring-cloud-starter-aws=2.2.6.RELEASE
 
+version.org.springframework.boot..spring-boot-starter-data-redis=3.3.0
+
 version.org.springframework.boot..spring-boot-configuration-processor=3.0.1
 
 version.io.sentry..sentry-logback=7.12.0


### PR DESCRIPTION
## 📌 개요 (필수)

- #132 연관 작업
- spring-redis 세팅

<br>

## 🔨 작업 사항 (필수)

- (gitignore) application-aws에 redis 추가 
- redis 설정파일 추가
- (리팩토링) InfrastructureConfig 생성 (JpaConfig, CacheConfig, AWSConfig 등 포함)
- dev, prod 배포를 위해 redis 환경변수를 추가했어요.
  - [컨플루언스](https://dpm-15th-6team.atlassian.net/wiki/spaces/SPOT/pages/1409025#ElastiCache-Redis-(ssh-tunneling-%ED%95%84%EC%9A%94))에 스펙 있음! 
 
<br>

## 🌱 연관 내용 (선택)

- ElastiCache에 터널링해서 접근해야 해요.
  - 로컬에서는 다음 방법 중 하나를 택해서 진행하면 됩니다.
    - (권장) 로컬에 redis 설치 후, application-aws에 localhost 넣고 쓰기
    - 로컬에서 ssh 터널링 한 후, application-aws에 dev 서버 host 넣고 쓰기
      - dev까진 괜찮은데, **로컬에서 prod에 직접 붙는건 XXXXXX 절대 금지! 주의해주세용**
- application-aws.yml 필요
  - [컨플루언스](https://dpm-15th-6team.atlassian.net/wiki/spaces/SPOT/pages/4882433/application-aws.yaml)에 추가 완료!