### PR TITLE
[BSVR-220] HashTag, BlockTag 도메인/엔티티 추가

### DIFF
--- a/domain/src/main/java/org/depromeet/spot/domain/block/BlockTag.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/block/BlockTag.java
@@ -1,0 +1,15 @@
+package org.depromeet.spot.domain.block;
+
+import org.depromeet.spot.domain.hashtag.HashTag;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BlockTag {
+
+    private final Long id;
+    private final Block block;
+    private final HashTag hashTag;
+}

--- a/domain/src/main/java/org/depromeet/spot/domain/hashtag/HashTag.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/hashtag/HashTag.java
@@ -1,0 +1,12 @@
+package org.depromeet.spot.domain.hashtag;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class HashTag {
+
+    private final Long id;
+    private final String name;
+}

--- a/domain/src/main/java/org/depromeet/spot/domain/hashtag/HashTag.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/hashtag/HashTag.java
@@ -9,4 +9,5 @@ public class HashTag {
 
     private final Long id;
     private final String name;
+    private final String description;
 }

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/block/entity/BlockTagEntity.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/block/entity/BlockTagEntity.java
@@ -11,7 +11,7 @@ import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.block.BlockTag;
 import org.depromeet.spot.infrastructure.jpa.common.entity.BaseEntity;
-import org.depromeet.spot.infrastructure.jpa.hashtag.HashTagEntity;
+import org.depromeet.spot.infrastructure.jpa.hashtag.entity.HashTagEntity;
 
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/block/entity/BlockTagEntity.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/block/entity/BlockTagEntity.java
@@ -1,0 +1,48 @@
+package org.depromeet.spot.infrastructure.jpa.block.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import org.depromeet.spot.domain.block.BlockTag;
+import org.depromeet.spot.infrastructure.jpa.common.entity.BaseEntity;
+import org.depromeet.spot.infrastructure.jpa.hashtag.HashTagEntity;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "block_tags")
+public class BlockTagEntity extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(
+            name = "block_id",
+            nullable = false,
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private BlockEntity block;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(
+            name = "hashtag_id",
+            nullable = false,
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private HashTagEntity hashTag;
+
+    public static BlockTagEntity from(BlockTag blockTag) {
+        BlockEntity blockEntity = BlockEntity.withBlock(blockTag.getBlock());
+        HashTagEntity hashTagEntity = HashTagEntity.from(blockTag.getHashTag());
+        return new BlockTagEntity(blockEntity, hashTagEntity);
+    }
+
+    public BlockTag toDomain() {
+        return new BlockTag(this.getId(), block.toDomain(), hashTag.toDomain());
+    }
+}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/block/repository/tag/BlockTagJpaRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/block/repository/tag/BlockTagJpaRepository.java
@@ -1,0 +1,6 @@
+package org.depromeet.spot.infrastructure.jpa.block.repository.tag;
+
+import org.depromeet.spot.infrastructure.jpa.block.entity.BlockTagEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlockTagJpaRepository extends JpaRepository<BlockTagEntity, Long> {}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/common/entity/BaseEntity.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/common/entity/BaseEntity.java
@@ -62,7 +62,7 @@ public abstract class BaseEntity {
         return this.deletedAt != null;
     }
 
-    public void setId(Long id) {
+    protected void setId(Long id) {
         this.id = id;
     }
 }

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/hashtag/HashTagEntity.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/hashtag/HashTagEntity.java
@@ -8,9 +8,11 @@ import org.depromeet.spot.domain.hashtag.HashTag;
 import org.depromeet.spot.infrastructure.jpa.common.entity.BaseEntity;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "hashtags")

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/hashtag/HashTagEntity.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/hashtag/HashTagEntity.java
@@ -1,0 +1,32 @@
+package org.depromeet.spot.infrastructure.jpa.hashtag;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+import org.depromeet.spot.domain.hashtag.HashTag;
+import org.depromeet.spot.infrastructure.jpa.common.entity.BaseEntity;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "hashtags")
+public class HashTagEntity extends BaseEntity {
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    public static HashTagEntity from(HashTag hashTag) {
+        HashTagEntity entity = new HashTagEntity();
+        entity.name = hashTag.getName();
+        if (hashTag.getId() != null) entity.setId(hashTag.getId());
+        return entity;
+    }
+
+    public HashTag toDomain() {
+        return new HashTag(this.getId(), name);
+    }
+}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/hashtag/entity/HashTagEntity.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/hashtag/entity/HashTagEntity.java
@@ -1,4 +1,4 @@
-package org.depromeet.spot.infrastructure.jpa.hashtag;
+package org.depromeet.spot.infrastructure.jpa.hashtag.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/hashtag/entity/HashTagEntity.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/hashtag/entity/HashTagEntity.java
@@ -21,14 +21,18 @@ public class HashTagEntity extends BaseEntity {
     @Column(name = "name", nullable = false)
     private String name;
 
+    @Column(name = "description", length = 255)
+    private String description;
+
     public static HashTagEntity from(HashTag hashTag) {
         HashTagEntity entity = new HashTagEntity();
         entity.name = hashTag.getName();
+        entity.description = hashTag.getDescription();
         if (hashTag.getId() != null) entity.setId(hashTag.getId());
         return entity;
     }
 
     public HashTag toDomain() {
-        return new HashTag(this.getId(), name);
+        return new HashTag(this.getId(), name, description);
     }
 }

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/hashtag/repository/HashTagJpaRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/hashtag/repository/HashTagJpaRepository.java
@@ -1,0 +1,6 @@
+package org.depromeet.spot.infrastructure.jpa.hashtag.repository;
+
+import org.depromeet.spot.infrastructure.jpa.hashtag.entity.HashTagEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HashTagJpaRepository extends JpaRepository<HashTagEntity, Long> {}

--- a/infrastructure/src/test/java/org/depromeet/spot/infrastructure/jpa/hashtag/HashTagEntityTest.java
+++ b/infrastructure/src/test/java/org/depromeet/spot/infrastructure/jpa/hashtag/HashTagEntityTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.depromeet.spot.domain.hashtag.HashTag;
+import org.depromeet.spot.infrastructure.jpa.hashtag.entity.HashTagEntity;
 import org.junit.jupiter.api.Test;
 
 class HashTagEntityTest {

--- a/infrastructure/src/test/java/org/depromeet/spot/infrastructure/jpa/hashtag/HashTagEntityTest.java
+++ b/infrastructure/src/test/java/org/depromeet/spot/infrastructure/jpa/hashtag/HashTagEntityTest.java
@@ -1,0 +1,40 @@
+package org.depromeet.spot.infrastructure.jpa.hashtag;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.depromeet.spot.domain.hashtag.HashTag;
+import org.junit.jupiter.api.Test;
+
+class HashTagEntityTest {
+
+    @Test
+    void 도메인을_entity로_매핑할_때_ID가_있는_도메인으로_entity를_생성할_수_있다() {
+        // given
+        final long id = 1L;
+        final String name = "해시태그";
+        HashTag hashTag = new HashTag(id, name);
+
+        // when
+        HashTagEntity entity = HashTagEntity.from(hashTag);
+
+        // then
+        assertEquals(id, entity.getId());
+        assertEquals(name, entity.getName());
+    }
+
+    @Test
+    void 신규_해시태그를_생성할_때_ID가_없는_도메인으로_entity를_생성할_수_있다() {
+        // given
+        final Long id = null;
+        final String name = "해시태그";
+        HashTag hashTag = new HashTag(id, name);
+
+        // when
+        HashTagEntity entity = HashTagEntity.from(hashTag);
+
+        // then
+        assertNull(entity.getId());
+        assertEquals(name, entity.getName());
+    }
+}

--- a/infrastructure/src/test/java/org/depromeet/spot/infrastructure/jpa/hashtag/HashTagEntityTest.java
+++ b/infrastructure/src/test/java/org/depromeet/spot/infrastructure/jpa/hashtag/HashTagEntityTest.java
@@ -13,8 +13,9 @@ class HashTagEntityTest {
     void 도메인을_entity로_매핑할_때_ID가_있는_도메인으로_entity를_생성할_수_있다() {
         // given
         final long id = 1L;
-        final String name = "해시태그";
-        HashTag hashTag = new HashTag(id, name);
+        final String name = "선수들과 가까이";
+        final String description = "선수들을 가까이에서 볼 수 있고 응원 분위기를 직접 느낄 수 있어요";
+        HashTag hashTag = new HashTag(id, name, description);
 
         // when
         HashTagEntity entity = HashTagEntity.from(hashTag);
@@ -22,14 +23,16 @@ class HashTagEntityTest {
         // then
         assertEquals(id, entity.getId());
         assertEquals(name, entity.getName());
+        assertEquals(description, entity.getDescription());
     }
 
     @Test
     void 신규_해시태그를_생성할_때_ID가_없는_도메인으로_entity를_생성할_수_있다() {
         // given
         final Long id = null;
-        final String name = "해시태그";
-        HashTag hashTag = new HashTag(id, name);
+        final String name = "선수들과 가까이";
+        final String description = "선수들을 가까이에서 볼 수 있고 응원 분위기를 직접 느낄 수 있어요";
+        HashTag hashTag = new HashTag(id, name, description);
 
         // when
         HashTagEntity entity = HashTagEntity.from(hashTag);
@@ -37,5 +40,6 @@ class HashTagEntityTest {
         // then
         assertNull(entity.getId());
         assertEquals(name, entity.getName());
+        assertEquals(description, entity.getDescription());
     }
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- 경기장별 블록 필터링 기능을 위해 해시태그 관련 도메인/엔티티를 추가해요.
- 한 블록은 여러 태그를 가질 수 있고, 태그에는 여러 블록이 포함될 수 있어요. (= 다대다)
<img width="386" alt="스크린샷 2024-08-18 오후 11 08 18" src="https://github.com/user-attachments/assets/a60063f1-d794-4681-9206-d71f34777548">

<br>

## 🔨 작업 사항 (필수)

- HashTag, BlockTag 도메인 추가
- HashTagEntity, BlockTagEntity 추가
- 관련 테스트코드 추가
- jpaRepository 추가

<br>

## 🌱 연관 내용 (선택)

- DB에 테이블은 미리 생성해뒀어요. [ref)](https://depromeet-15th.slack.com/archives/C075Z9K5QH4/p1723985648038789)

<br>

## 💻 실행 화면 (필수)

<img width="1104" alt="스크린샷 2024-08-18 오후 11 11 50" src="https://github.com/user-attachments/assets/f4b7da9f-4c6e-4168-aa60-82aaeacf68fe">
local에서 hibernate.ddl-auto=validate로 했을 때 잘 돌아감~
