### PR TITLE
[BSVR-224] 리뷰에서 seat nullable하게 수정 2 + totalElements 필드 추가

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/BaseReviewResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/BaseReviewResponse.java
@@ -113,6 +113,7 @@ public record BaseReviewResponse(
     public record SeatResponse(Long id, Integer seatNumber) {
 
         public static SeatResponse from(Seat seat) {
+            if (seat == null) return null;
             return new SeatResponse(seat.getId(), seat.getSeatNumber());
         }
     }

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/BlockReviewListResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/BlockReviewListResponse.java
@@ -12,6 +12,7 @@ public record BlockReviewListResponse(
         List<KeywordCountResponse> keywords,
         List<BaseReviewResponse> reviews,
         List<TopReviewImageResponse> topReviewImages,
+        Long totalElements,
         String nextCursor,
         boolean hasNext,
         FilterInfo filter) {
@@ -39,6 +40,7 @@ public record BlockReviewListResponse(
                 keywordResponses,
                 reviewResponses,
                 topReviewImageResponses,
+                result.totalElements(),
                 result.nextCursor(),
                 result.hasNext(),
                 filter);

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewCustomRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewCustomRepository.java
@@ -139,6 +139,26 @@ public class ReviewCustomRepository {
                 .fetchOne();
     }
 
+    public long countByStadiumIdAndBlockCode(
+            Long stadiumId,
+            String blockCode,
+            Integer rowNumber,
+            Integer seatNumber,
+            Integer year,
+            Integer month) {
+        BooleanBuilder builder =
+                buildConditions(stadiumId, blockCode, rowNumber, seatNumber, year, month);
+
+        Long count =
+                queryFactory
+                        .select(reviewEntity.count())
+                        .from(reviewEntity)
+                        .where(builder)
+                        .fetchOne();
+
+        return count != null ? count : 0L;
+    }
+
     private BooleanBuilder buildConditions(
             Long stadiumId,
             String blockCode,

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewRepositoryImpl.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewRepositoryImpl.java
@@ -109,4 +109,16 @@ public class ReviewRepositoryImpl implements ReviewRepository {
     public long countByIdByMemberId(Long memberId) {
         return reviewJpaRepository.countByIdByMemberId(memberId);
     }
+
+    @Override
+    public long countByStadiumIdAndBlockCode(
+            Long stadiumId,
+            String blockCode,
+            Integer rowNumber,
+            Integer seatNumber,
+            Integer year,
+            Integer month) {
+        return reviewCustomRepository.countByStadiumIdAndBlockCode(
+                stadiumId, blockCode, rowNumber, seatNumber, year, month);
+    }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
@@ -47,6 +47,7 @@ public interface ReadReviewUsecase {
             List<Review> reviews,
             List<BlockKeywordInfo> topKeywords,
             List<TopReviewImage> topReviewImages,
+            Long totalElements,
             String nextCursor,
             boolean hasNext) {}
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewRepository.java
@@ -43,4 +43,12 @@ public interface ReviewRepository {
     Review findLastReviewByMemberId(Long memberId);
 
     long countByIdByMemberId(Long memberId);
+
+    long countByStadiumIdAndBlockCode(
+            Long stadiumId,
+            String blockCode,
+            Integer rowNumber,
+            Integer seatNumber,
+            Integer year,
+            Integer month);
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -86,11 +86,16 @@ public class ReadReviewService implements ReadReviewUsecase {
 
         List<Review> reviewsWithKeywords = mapKeywordsToReviews(reviews);
 
+        long totalElements =
+                reviewRepository.countByStadiumIdAndBlockCode(
+                        stadiumId, blockCode, rowNumber, seatNumber, year, month);
+
         return BlockReviewListResult.builder()
                 .location(locationInfo)
                 .reviews(reviewsWithKeywords)
                 .topKeywords(topKeywords)
                 .topReviewImages(topReviewImages)
+                .totalElements(totalElements)
                 .nextCursor(nextCursor)
                 .hasNext(hasNext)
                 .build();


### PR DESCRIPTION
## 📌 개요 (필수)

- 리뷰에서 seat nullable하게 수정 2 + totalElements 필드 추가

<br>

## 🔨 작업 사항 (필수)

- BaseReviewResponse에서 빠진 seat nullable 처리
- block 리뷰 조회에서 요구사항에 따라 total elements 필드 추가
- [관련 스레드](https://depromeet-15th.slack.com/archives/C075Z9K5QH4/p1724050120911709?thread_ts=1723474743.177719&cid=C075Z9K5QH4)
<br>

## ⚡️ 관심 리뷰 (선택)

- 커서 기반으로 해서 전체를 다 훑을 필요없이 정렬 후 size 만큼만 가져오는 최적화를 수행했었는데,, 
- 아이러니하게도 요구사항 상 전체 개수가 필요해서 어쩔 수 없이 필터 조건에 따라 항상 전체 element 수를 가져와야하기 때문에 풀스캔을 때려야한다... 최적화 방법이 있을까? 

<br>

## 💻 실행 화면 (필수)

![image](https://github.com/user-attachments/assets/c011b80f-ebb5-4099-92e1-e3c127b56046)
