### PR TITLE
[BSVR-221] 특정 경기장 상세 정보 조회 API에 구역 정보, 블록 해시태그 정보 추가

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumBlockTagResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumBlockTagResponse.java
@@ -1,0 +1,13 @@
+package org.depromeet.spot.application.stadium.dto.response;
+
+import java.util.List;
+
+import org.depromeet.spot.usecase.port.in.stadium.StadiumReadUsecase.StadiumBlockTagInfo;
+
+public record StadiumBlockTagResponse(
+        long id, String name, List<String> blockCodes, String description) {
+    public static StadiumBlockTagResponse from(StadiumBlockTagInfo info) {
+        return new StadiumBlockTagResponse(
+                info.getId(), info.getName(), info.getBlockCodes(), info.getDescription());
+    }
+}

--- a/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumInfoWithSeatChartResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumInfoWithSeatChartResponse.java
@@ -12,7 +12,9 @@ public record StadiumInfoWithSeatChartResponse(
         String name,
         String seatChartWithLabel,
         String thumbnail,
-        List<HomeTeamInfoResponse> homeTeams) {
+        List<HomeTeamInfoResponse> homeTeams,
+        List<StadiumSectionInfoResponse> sections,
+        List<StadiumBlockTagResponse> blockTags) {
 
     public static StadiumInfoWithSeatChartResponse from(
             StadiumInfoWithSeatChart stadiumInfoWithSeatChart) {
@@ -21,11 +23,23 @@ public record StadiumInfoWithSeatChartResponse(
                         .map(HomeTeamInfoResponse::from)
                         .toList();
 
+        List<StadiumSectionInfoResponse> sections =
+                stadiumInfoWithSeatChart.getSections().stream()
+                        .map(StadiumSectionInfoResponse::from)
+                        .toList();
+
+        List<StadiumBlockTagResponse> blockTags =
+                stadiumInfoWithSeatChart.getBlockTags().stream()
+                        .map(StadiumBlockTagResponse::from)
+                        .toList();
+
         return new StadiumInfoWithSeatChartResponse(
                 stadiumInfoWithSeatChart.getId(),
                 stadiumInfoWithSeatChart.getName(),
                 stadiumInfoWithSeatChart.getSeatChartWithLabel(),
                 stadiumInfoWithSeatChart.getThumbnail(),
-                homeTeams);
+                homeTeams,
+                sections,
+                blockTags);
     }
 }

--- a/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumSectionInfoResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/stadium/dto/response/StadiumSectionInfoResponse.java
@@ -1,0 +1,9 @@
+package org.depromeet.spot.application.stadium.dto.response;
+
+import org.depromeet.spot.usecase.port.in.stadium.StadiumReadUsecase.StadiumSectionInfo;
+
+public record StadiumSectionInfoResponse(long id, String name, String alias) {
+    public static StadiumSectionInfoResponse from(StadiumSectionInfo info) {
+        return new StadiumSectionInfoResponse(info.getId(), info.getName(), info.getAlias());
+    }
+}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/block/entity/BlockTagEntity.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/block/entity/BlockTagEntity.java
@@ -14,9 +14,11 @@ import org.depromeet.spot.infrastructure.jpa.common.entity.BaseEntity;
 import org.depromeet.spot.infrastructure.jpa.hashtag.entity.HashTagEntity;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "block_tags")

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/block/repository/tag/BlockTagCustomRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/block/repository/tag/BlockTagCustomRepository.java
@@ -1,0 +1,43 @@
+package org.depromeet.spot.infrastructure.jpa.block.repository.tag;
+
+import static org.depromeet.spot.infrastructure.jpa.block.entity.QBlockEntity.blockEntity;
+import static org.depromeet.spot.infrastructure.jpa.block.entity.QBlockTagEntity.blockTagEntity;
+import static org.depromeet.spot.infrastructure.jpa.hashtag.entity.QHashTagEntity.hashTagEntity;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.depromeet.spot.infrastructure.jpa.block.entity.BlockEntity;
+import org.depromeet.spot.infrastructure.jpa.block.entity.BlockTagEntity;
+import org.depromeet.spot.infrastructure.jpa.hashtag.entity.HashTagEntity;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BlockTagCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Map<HashTagEntity, List<BlockEntity>> findAllByStadium(Long stadiumId) {
+        List<BlockTagEntity> blockTagEntities =
+                queryFactory
+                        .selectFrom(blockTagEntity)
+                        .join(blockTagEntity.block, blockEntity)
+                        .fetchJoin()
+                        .join(blockTagEntity.hashTag, hashTagEntity)
+                        .fetchJoin()
+                        .where(blockEntity.stadiumId.eq(stadiumId))
+                        .fetch();
+
+        return blockTagEntities.stream()
+                .collect(
+                        Collectors.groupingBy(
+                                BlockTagEntity::getHashTag,
+                                Collectors.mapping(BlockTagEntity::getBlock, Collectors.toList())));
+    }
+}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/block/repository/tag/BlockTagJpaRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/block/repository/tag/BlockTagJpaRepository.java
@@ -1,6 +1,0 @@
-package org.depromeet.spot.infrastructure.jpa.block.repository.tag;
-
-import org.depromeet.spot.infrastructure.jpa.block.entity.BlockTagEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface BlockTagJpaRepository extends JpaRepository<BlockTagEntity, Long> {}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/block/repository/tag/BlockTagRepositoryImpl.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/block/repository/tag/BlockTagRepositoryImpl.java
@@ -1,0 +1,35 @@
+package org.depromeet.spot.infrastructure.jpa.block.repository.tag;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.depromeet.spot.domain.block.Block;
+import org.depromeet.spot.domain.hashtag.HashTag;
+import org.depromeet.spot.infrastructure.jpa.block.entity.BlockEntity;
+import org.depromeet.spot.infrastructure.jpa.hashtag.entity.HashTagEntity;
+import org.depromeet.spot.usecase.port.out.block.BlockTagRepository;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BlockTagRepositoryImpl implements BlockTagRepository {
+
+    private final BlockTagCustomRepository blockTagCustomRepository;
+
+    @Override
+    public Map<HashTag, List<Block>> findAllByStadium(Long stadiumId) {
+        Map<HashTagEntity, List<BlockEntity>> entities =
+                blockTagCustomRepository.findAllByStadium(stadiumId);
+        return entities.entrySet().stream()
+                .collect(
+                        Collectors.toMap(
+                                entry -> entry.getKey().toDomain(),
+                                entry ->
+                                        entry.getValue().stream()
+                                                .map(BlockEntity::toDomain)
+                                                .toList()));
+    }
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/block/ReadBlockTagUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/block/ReadBlockTagUsecase.java
@@ -1,0 +1,12 @@
+package org.depromeet.spot.usecase.port.in.block;
+
+import java.util.List;
+import java.util.Map;
+
+import org.depromeet.spot.domain.block.Block;
+import org.depromeet.spot.domain.hashtag.HashTag;
+
+public interface ReadBlockTagUsecase {
+
+    Map<HashTag, List<Block>> findAllByStadium(Long stadiumId);
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/section/SectionReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/section/SectionReadUsecase.java
@@ -10,6 +10,8 @@ import lombok.Getter;
 
 public interface SectionReadUsecase {
 
+    List<Section> findAllBy(Long stadiumId);
+
     StadiumSections findAllByStadium(Long stadiumId);
 
     boolean existsInStadium(Long stadiumId, Long sectionId);

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/StadiumReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/StadiumReadUsecase.java
@@ -2,6 +2,7 @@ package org.depromeet.spot.usecase.port.in.stadium;
 
 import java.util.List;
 
+import org.depromeet.spot.domain.section.Section;
 import org.depromeet.spot.domain.stadium.Stadium;
 import org.depromeet.spot.usecase.port.in.team.ReadStadiumHomeTeamUsecase.HomeTeamInfo;
 
@@ -60,6 +61,10 @@ public interface StadiumReadUsecase {
         private final long id;
         private final String name;
         private final String alias;
+
+        public static StadiumSectionInfo from(Section section) {
+            return new StadiumSectionInfo(section.getId(), section.getName(), section.getAlias());
+        }
     }
 
     @Getter

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/StadiumReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/StadiumReadUsecase.java
@@ -42,6 +42,8 @@ public interface StadiumReadUsecase {
         private final List<HomeTeamInfo> homeTeams;
         private final String seatChartWithLabel;
         private final String thumbnail;
+        private final List<StadiumSectionInfo> sections;
+        private final List<StadiumBlockTagInfo> blockTags;
     }
 
     @Getter
@@ -50,5 +52,22 @@ public interface StadiumReadUsecase {
         private final Long id;
         private final String name;
         private final boolean isActive;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    class StadiumSectionInfo {
+        private final long id;
+        private final String name;
+        private final String alias;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    class StadiumBlockTagInfo {
+        private final long id;
+        private final String name;
+        private final List<String> blockCodes;
+        private final String description;
     }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/StadiumReadUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/stadium/StadiumReadUsecase.java
@@ -68,7 +68,7 @@ public interface StadiumReadUsecase {
     }
 
     @Getter
-    @AllArgsConstructor
+    @Builder
     class StadiumBlockTagInfo {
         private final long id;
         private final String name;

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/block/BlockTagRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/block/BlockTagRepository.java
@@ -1,0 +1,12 @@
+package org.depromeet.spot.usecase.port.out.block;
+
+import java.util.List;
+import java.util.Map;
+
+import org.depromeet.spot.domain.block.Block;
+import org.depromeet.spot.domain.hashtag.HashTag;
+
+public interface BlockTagRepository {
+
+    Map<HashTag, List<Block>> findAllByStadium(Long stadiumId);
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/block/ReadBlockTagService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/block/ReadBlockTagService.java
@@ -1,0 +1,26 @@
+package org.depromeet.spot.usecase.service.block;
+
+import java.util.List;
+import java.util.Map;
+
+import org.depromeet.spot.domain.block.Block;
+import org.depromeet.spot.domain.hashtag.HashTag;
+import org.depromeet.spot.usecase.port.in.block.ReadBlockTagUsecase;
+import org.depromeet.spot.usecase.port.out.block.BlockTagRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReadBlockTagService implements ReadBlockTagUsecase {
+
+    private final BlockTagRepository blockTagRepository;
+
+    @Override
+    public Map<HashTag, List<Block>> findAllByStadium(final Long stadiumId) {
+        return blockTagRepository.findAllByStadium(stadiumId);
+    }
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/section/SectionReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/section/SectionReadService.java
@@ -24,6 +24,11 @@ public class SectionReadService implements SectionReadUsecase {
     private final SectionRepository sectionRepository;
 
     @Override
+    public List<Section> findAllBy(final Long stadiumId) {
+        return sectionRepository.findAllByStadium(stadiumId);
+    }
+
+    @Override
     public StadiumSections findAllByStadium(final Long stadiumId) {
         Stadium stadium = stadiumReadUsecase.findById(stadiumId);
         List<Section> sections = sectionRepository.findAllByStadium(stadiumId);

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/StadiumReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/StadiumReadService.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.depromeet.spot.common.exception.stadium.StadiumException.StadiumNotFoundException;
 import org.depromeet.spot.domain.stadium.Stadium;
 import org.depromeet.spot.domain.team.BaseballTeam;
+import org.depromeet.spot.usecase.port.in.section.SectionReadUsecase;
 import org.depromeet.spot.usecase.port.in.stadium.StadiumReadUsecase;
 import org.depromeet.spot.usecase.port.in.team.ReadStadiumHomeTeamUsecase;
 import org.depromeet.spot.usecase.port.in.team.ReadStadiumHomeTeamUsecase.HomeTeamInfo;
@@ -25,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class StadiumReadService implements StadiumReadUsecase {
 
     private final ReadStadiumHomeTeamUsecase readStadiumHomeTeamUsecase;
+    private final SectionReadUsecase sectionReadUsecase;
     private final StadiumRepository stadiumRepository;
 
     @Override
@@ -74,6 +76,8 @@ public class StadiumReadService implements StadiumReadUsecase {
     @Override
     public StadiumInfoWithSeatChart findWithSeatChartById(final Long id) {
         Stadium stadium = stadiumRepository.findById(id);
+        List<StadiumSectionInfo> sections =
+                sectionReadUsecase.findAllBy(id).stream().map(StadiumSectionInfo::from).toList();
         List<HomeTeamInfo> homeTeams = readStadiumHomeTeamUsecase.findByStadium(id);
         return StadiumInfoWithSeatChart.builder()
                 .id(stadium.getId())
@@ -81,6 +85,7 @@ public class StadiumReadService implements StadiumReadUsecase {
                 .homeTeams(homeTeams)
                 .thumbnail(stadium.getMainImage())
                 .seatChartWithLabel(stadium.getLabeledSeatingChartImage())
+                .sections(sections)
                 .build();
     }
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/StadiumReadService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/stadium/StadiumReadService.java
@@ -11,10 +11,10 @@ import org.depromeet.spot.domain.block.Block;
 import org.depromeet.spot.domain.hashtag.HashTag;
 import org.depromeet.spot.domain.stadium.Stadium;
 import org.depromeet.spot.domain.team.BaseballTeam;
-import org.depromeet.spot.usecase.port.in.section.SectionReadUsecase;
 import org.depromeet.spot.usecase.port.in.stadium.StadiumReadUsecase;
 import org.depromeet.spot.usecase.port.in.team.ReadStadiumHomeTeamUsecase;
 import org.depromeet.spot.usecase.port.in.team.ReadStadiumHomeTeamUsecase.HomeTeamInfo;
+import org.depromeet.spot.usecase.port.out.section.SectionRepository;
 import org.depromeet.spot.usecase.port.out.stadium.StadiumRepository;
 import org.depromeet.spot.usecase.service.block.ReadBlockTagService;
 import org.springframework.stereotype.Service;
@@ -31,7 +31,7 @@ public class StadiumReadService implements StadiumReadUsecase {
 
     private final ReadStadiumHomeTeamUsecase readStadiumHomeTeamUsecase;
     private final ReadBlockTagService readBlockTagService;
-    private final SectionReadUsecase sectionReadUsecase;
+    private final SectionRepository sectionRepository;
     private final StadiumRepository stadiumRepository;
 
     @Override
@@ -82,7 +82,9 @@ public class StadiumReadService implements StadiumReadUsecase {
     public StadiumInfoWithSeatChart findWithSeatChartById(final Long id) {
         Stadium stadium = stadiumRepository.findById(id);
         List<StadiumSectionInfo> sections =
-                sectionReadUsecase.findAllBy(id).stream().map(StadiumSectionInfo::from).toList();
+                sectionRepository.findAllByStadium(id).stream()
+                        .map(StadiumSectionInfo::from)
+                        .toList();
         List<HomeTeamInfo> homeTeams = readStadiumHomeTeamUsecase.findByStadium(id);
         List<StadiumBlockTagInfo> blockTags = makeBlockTagInfoByStadium(id);
         return StadiumInfoWithSeatChart.builder()


### PR DESCRIPTION
## 📌 개요 (필수)

- 2차 MVP GUI 변경 -> 구역 일괄 선택 기능, 블록 필터링 기능이 추가되었어요.
- 위 변경에 맞춰 필요한 res를 추가해요.

<br>

## 🔨 작업 사항 (필수)

- 해시태그에 description 필드 추가
- 경기장별 구역 정보값 추가
- 경기장별 블럭 해시태그 정보값 추가

<br>

## 💻 실행 화면 (필수)

<img width="691" alt="스크린샷 2024-08-20 오후 11 03 25" src="https://github.com/user-attachments/assets/32e24122-ca63-4000-81a5-6518413c1435">

추가된 필드 부분만 캡처했어요~
