### PR TITLE
[BSVR-227] 스크랩 토글 API 구현

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/review/scrap/ReviewScrapController.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/scrap/ReviewScrapController.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 import org.depromeet.spot.application.common.annotation.CurrentMember;
+import org.depromeet.spot.usecase.port.in.review.scrap.ReviewScrapUsecase;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,9 +28,9 @@ public class ReviewScrapController {
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "특정 리뷰를 스크랩한다. 만약 이전에 스크랩했던 리뷰라면, 스크랩을 취소한다.")
     @PostMapping("/{reviewId}/scrap")
-    public void toggleLike(
+    public boolean toggleScrap(
             @PathVariable @Positive @NotNull final Long reviewId,
             @Parameter(hidden = true) Long memberId) {
-        reviewScrapUsecase.toggleScrap(memberId, reviewId);
+        return reviewScrapUsecase.toggleScrap(memberId, reviewId);
     }
 }

--- a/application/src/main/java/org/depromeet/spot/application/review/scrap/ReviewScrapController.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/scrap/ReviewScrapController.java
@@ -1,0 +1,35 @@
+package org.depromeet.spot.application.review.scrap;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import org.depromeet.spot.application.common.annotation.CurrentMember;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@Tag(name = "리뷰 공감")
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/reviews")
+public class ReviewScrapController {
+    private final ReviewScrapUsecase reviewScrapUsecase;
+
+    @CurrentMember
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "특정 리뷰를 스크랩한다. 만약 이전에 스크랩했던 리뷰라면, 스크랩을 취소한다.")
+    @PostMapping("/{reviewId}/scrap")
+    public void toggleLike(
+            @PathVariable @Positive @NotNull final Long reviewId,
+            @Parameter(hidden = true) Long memberId) {
+        reviewScrapUsecase.toggleScrap(memberId, reviewId);
+    }
+}

--- a/domain/src/main/java/org/depromeet/spot/domain/review/scrap/ReviewScrap.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/review/scrap/ReviewScrap.java
@@ -1,0 +1,14 @@
+package org.depromeet.spot.domain.review.scrap;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ReviewScrap {
+    private final Long id;
+    private final Long memberId;
+    private final Long reviewId;
+}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/entity/scrap/ReviewScrapEntity.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/entity/scrap/ReviewScrapEntity.java
@@ -1,0 +1,31 @@
+package org.depromeet.spot.infrastructure.jpa.review.entity.scrap;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+import org.depromeet.spot.domain.review.scrap.ReviewScrap;
+import org.depromeet.spot.infrastructure.jpa.common.entity.BaseEntity;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "review_scraps")
+public class ReviewScrapEntity extends BaseEntity {
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "review_id", nullable = false)
+    private Long reviewId;
+
+    public static ReviewScrapEntity from(ReviewScrap scrap) {
+        return new ReviewScrapEntity(scrap.getMemberId(), scrap.getReviewId());
+    }
+
+    public ReviewScrap toDomain() {
+        return ReviewScrap.builder().id(this.getId()).memberId(memberId).reviewId(reviewId).build();
+    }
+}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/scrap/ReviewScrapJpaRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/scrap/ReviewScrapJpaRepository.java
@@ -1,0 +1,14 @@
+package org.depromeet.spot.infrastructure.jpa.review.repository.scrap;
+
+import org.depromeet.spot.infrastructure.jpa.review.entity.scrap.ReviewScrapEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+
+public interface ReviewScrapJpaRepository extends JpaRepository<ReviewScrapEntity, Integer> {
+    long countByReviewId(long reviewId);
+
+    boolean existsByMemberIdAndReviewId(long memberId, long reviewId);
+
+    @Modifying
+    void deleteByMemberIdAndReviewId(long memberId, long reviewId);
+}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/scrap/ReviewScrapRepositoryImpl.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/scrap/ReviewScrapRepositoryImpl.java
@@ -1,0 +1,36 @@
+package org.depromeet.spot.infrastructure.jpa.review.repository.scrap;
+
+import org.depromeet.spot.domain.review.scrap.ReviewScrap;
+import org.depromeet.spot.infrastructure.jpa.review.entity.scrap.ReviewScrapEntity;
+import org.depromeet.spot.usecase.port.out.review.ReviewScrapRepository;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewScrapRepositoryImpl implements ReviewScrapRepository {
+
+    private final ReviewScrapJpaRepository reviewScrapJpaRepository;
+
+    @Override
+    public boolean existsBy(final long memberId, final long reviewId) {
+        return reviewScrapJpaRepository.existsByMemberIdAndReviewId(memberId, reviewId);
+    }
+
+    @Override
+    public long countByReview(final long reviewId) {
+        return reviewScrapJpaRepository.countByReviewId(reviewId);
+    }
+
+    @Override
+    public void deleteBy(final long memberId, final long reviewId) {
+        reviewScrapJpaRepository.deleteByMemberIdAndReviewId(memberId, reviewId);
+    }
+
+    @Override
+    public void save(ReviewScrap scrap) {
+        ReviewScrapEntity entity = ReviewScrapEntity.from(scrap);
+        reviewScrapJpaRepository.save(entity);
+    }
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/scrap/ReviewScrapUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/scrap/ReviewScrapUsecase.java
@@ -1,0 +1,5 @@
+package org.depromeet.spot.usecase.port.in.review.scrap;
+
+public interface ReviewScrapUsecase {
+    boolean toggleScrap(long memberId, long reviewId);
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewScrapRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewScrapRepository.java
@@ -1,0 +1,13 @@
+package org.depromeet.spot.usecase.port.out.review;
+
+import org.depromeet.spot.domain.review.scrap.ReviewScrap;
+
+public interface ReviewScrapRepository {
+    boolean existsBy(long memberId, long reviewId);
+
+    long countByReview(long reviewId);
+
+    void deleteBy(long memberId, long reviewId);
+
+    void save(ReviewScrap like);
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/scrap/ReviewScrapService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/scrap/ReviewScrapService.java
@@ -1,0 +1,41 @@
+package org.depromeet.spot.usecase.service.review.scrap;
+
+import org.depromeet.spot.domain.review.scrap.ReviewScrap;
+import org.depromeet.spot.usecase.port.in.review.scrap.ReviewScrapUsecase;
+import org.depromeet.spot.usecase.port.out.review.ReviewScrapRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReviewScrapService implements ReviewScrapUsecase {
+    private final ReviewScrapRepository reviewScrapRepository;
+
+    @Override
+    public boolean toggleScrap(final long memberId, final long reviewId) {
+        if (isScraped(memberId, reviewId)) {
+            cancelScrap(memberId, reviewId);
+            return false;
+        }
+
+        addScrap(memberId, reviewId);
+        return true;
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isScraped(final long memberId, final long reviewId) {
+        return reviewScrapRepository.existsBy(memberId, reviewId);
+    }
+
+    public void cancelScrap(final long memberId, final long reviewId) {
+        reviewScrapRepository.deleteBy(memberId, reviewId);
+    }
+
+    public void addScrap(final long memberId, final long reviewId) {
+        ReviewScrap like = ReviewScrap.builder().memberId(memberId).reviewId(reviewId).build();
+        reviewScrapRepository.save(like);
+    }
+}

--- a/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeReviewScrapRepository.java
+++ b/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeReviewScrapRepository.java
@@ -1,0 +1,46 @@
+package org.depromeet.spot.usecase.service.fake;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.depromeet.spot.domain.review.scrap.ReviewScrap;
+import org.depromeet.spot.usecase.port.out.review.ReviewScrapRepository;
+
+public class FakeReviewScrapRepository implements ReviewScrapRepository {
+
+    private final List<ReviewScrap> scraps = new ArrayList<>();
+
+    @Override
+    public boolean existsBy(final long memberId, final long reviewId) {
+        return scraps.stream()
+                .anyMatch(
+                        scrap ->
+                                scrap.getMemberId() == memberId && scrap.getReviewId() == reviewId);
+    }
+
+    @Override
+    public long countByReview(final long reviewId) {
+        return scraps.stream().filter(scrap -> scrap.getReviewId() == reviewId).count();
+    }
+
+    @Override
+    public void deleteBy(final long memberId, final long reviewId) {
+        scraps.removeIf(
+                scrap -> scrap.getMemberId() == memberId && scrap.getReviewId() == reviewId);
+    }
+
+    @Override
+    public void save(ReviewScrap scrap) {
+        // 이미 존재하는 경우 업데이트, 그렇지 않으면 새로 추가
+        deleteBy(scrap.getMemberId(), scrap.getReviewId());
+        scraps.add(scrap);
+    }
+
+    public void clear() {
+        scraps.clear();
+    }
+
+    public List<ReviewScrap> findAll() {
+        return new ArrayList<>(scraps);
+    }
+}

--- a/usecase/src/test/java/org/depromeet/spot/usecase/service/review/ReviewScrapServiceTest.java
+++ b/usecase/src/test/java/org/depromeet/spot/usecase/service/review/ReviewScrapServiceTest.java
@@ -1,0 +1,95 @@
+package org.depromeet.spot.usecase.service.review;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.depromeet.spot.domain.review.scrap.ReviewScrap;
+import org.depromeet.spot.usecase.service.fake.FakeReviewScrapRepository;
+import org.depromeet.spot.usecase.service.review.scrap.ReviewScrapService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ReviewScrapServiceTest {
+
+    private ReviewScrapService reviewScrapService;
+    private FakeReviewScrapRepository fakeReviewScrapRepository;
+
+    @BeforeEach
+    void init() {
+        fakeReviewScrapRepository = new FakeReviewScrapRepository();
+        reviewScrapService = new ReviewScrapService(fakeReviewScrapRepository);
+    }
+
+    @Test
+    void 스크랩_추가() {
+        // given
+        long memberId = 1L;
+        long reviewId = 1L;
+
+        // when
+        boolean result = reviewScrapService.toggleScrap(memberId, reviewId);
+
+        // then
+        assertTrue(result);
+        assertTrue(fakeReviewScrapRepository.existsBy(memberId, reviewId));
+    }
+
+    @Test
+    void 스크랩_제거() {
+        // given
+        long memberId = 1L;
+        long reviewId = 1L;
+        ReviewScrap scrap = ReviewScrap.builder().memberId(memberId).reviewId(reviewId).build();
+        fakeReviewScrapRepository.save(scrap);
+
+        // when
+        boolean result = reviewScrapService.toggleScrap(memberId, reviewId);
+
+        // then
+        assertFalse(result);
+        assertFalse(fakeReviewScrapRepository.existsBy(memberId, reviewId));
+    }
+
+    @Test
+    void 스크랩_개수_확인() {
+        // given
+        long reviewId = 1L;
+        ReviewScrap scrap1 = ReviewScrap.builder().memberId(1L).reviewId(reviewId).build();
+        ReviewScrap scrap2 = ReviewScrap.builder().memberId(2L).reviewId(reviewId).build();
+        fakeReviewScrapRepository.save(scrap1);
+        fakeReviewScrapRepository.save(scrap2);
+
+        // when
+        long count = fakeReviewScrapRepository.countByReview(reviewId);
+
+        // then
+        assertEquals(2, count);
+    }
+
+    @Test
+    void 스크랩_여부_확인() {
+        // given
+        long memberId = 1L;
+        long reviewId = 1L;
+        ReviewScrap scrap = ReviewScrap.builder().memberId(memberId).reviewId(reviewId).build();
+        fakeReviewScrapRepository.save(scrap);
+
+        // when
+        boolean exists = reviewScrapService.isScraped(memberId, reviewId);
+
+        // then
+        assertTrue(exists);
+    }
+
+    @Test
+    void 존재하지_않는_스크랩_여부_확인() {
+        // given
+        long memberId = 1L;
+        long reviewId = 1L;
+
+        // when
+        boolean exists = reviewScrapService.isScraped(memberId, reviewId);
+
+        // then
+        assertFalse(exists);
+    }
+}


### PR DESCRIPTION
## 📌 개요 (필수)

- https://www.notion.so/depromeet/or-ea77aa315bdb43ee8954c23a9252be17?pvs=4
- 특정 리뷰의 스크랩을 추가하고 제거하는 api를 구현했어요.
- 공감과 마찬가지로 서버에서 스크랩 여부를 확인해서 api 하나로 스크랩 추가와 제거를 통일했어요.

<br>

## 🔨 작업 사항 (필수)

- controller, service, repository 구현
- 테스트코드 구현

<br>

## ⚡️ 관심 리뷰 (선택)

- X

<br>

## 🌱 연관 내용 (선택)

- review scrap 테이블 추가
 
```mysql
CREATE TABLE `review_scraps` (
  `id` bigint NOT NULL AUTO_INCREMENT,
  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
  `updated_at` datetime DEFAULT CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP,
  `deleted_at` datetime DEFAULT NULL,
  `member_id` bigint NOT NULL ,
  `review_id` bigint NOT NULL ,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

```

<br>

## 💻 실행 화면 (필수)

- 테스트 통과

![image](https://github.com/user-attachments/assets/f1439a36-8f1e-49b7-ba50-7051616737a4)

- 추가할 땐 true 반환, 제거할 땐 false 반환

![image](https://github.com/user-attachments/assets/0c69ac08-42be-4887-9f4f-c768dd16f75c)

- review scrap 테이블 추가

<img width="1002" alt="image" src="https://github.com/user-attachments/assets/25d9013f-d1a8-43d7-a492-7901c1b0908d">

