### PR TITLE
[BSVR-231] 스크랩 개수 저장 로직 추가

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/BaseReviewResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/BaseReviewResponse.java
@@ -26,7 +26,8 @@ public record BaseReviewResponse(
         String content,
         List<ReviewImageResponse> images,
         List<KeywordResponse> keywords,
-        int likesCount) {
+        int likesCount,
+        int scrapsCount) {
 
     public static BaseReviewResponse from(CreateReviewResult result) {
         Review review = result.review();
@@ -54,7 +55,8 @@ public record BaseReviewResponse(
                                             keyword.getIsPositive());
                                 })
                         .toList(),
-                review.getLikesCount());
+                review.getLikesCount(),
+                review.getScrapsCount());
     }
 
     public static BaseReviewResponse from(Review review) {
@@ -82,7 +84,8 @@ public record BaseReviewResponse(
                                             keyword.getIsPositive());
                                 })
                         .collect(Collectors.toList()),
-                review.getLikesCount());
+                review.getLikesCount(),
+                review.getScrapsCount());
     }
 
     public record StadiumResponse(Long id, String name) {

--- a/application/src/main/java/org/depromeet/spot/application/review/scrap/ReviewScrapController.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/scrap/ReviewScrapController.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/reviews")
 public class ReviewScrapController {
+
     private final ReviewScrapUsecase reviewScrapUsecase;
 
     @CurrentMember

--- a/domain/src/main/java/org/depromeet/spot/domain/review/Review.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/review/Review.java
@@ -36,6 +36,7 @@ public class Review {
     private List<ReviewKeyword> keywords;
     private transient Map<Long, Keyword> keywordMap;
     private int likesCount;
+    private int scrapsCount;
 
     public static final int DEFAULT_LIKE_COUNT = 0;
 
@@ -53,7 +54,8 @@ public class Review {
             LocalDateTime deletedAt,
             List<ReviewImage> images,
             List<ReviewKeyword> keywords,
-            int likesCount) {
+            int likesCount,
+            int scrapsCount) {
         if (likesCount < 0) {
             throw new InvalidReviewLikesException();
         }
@@ -71,6 +73,7 @@ public class Review {
         this.images = images != null ? images : new ArrayList<>();
         this.keywords = keywords != null ? keywords : new ArrayList<>();
         this.likesCount = likesCount;
+        this.scrapsCount = scrapsCount;
     }
 
     public void addKeyword(ReviewKeyword keyword) {
@@ -107,6 +110,16 @@ public class Review {
     public void cancelLike() {
         if (this.likesCount > 0) {
             this.likesCount--;
+        }
+    }
+
+    public void addScrap() {
+        this.scrapsCount++;
+    }
+
+    public void cancelScrap() {
+        if (this.scrapsCount > 0) {
+            this.scrapsCount--;
         }
     }
 

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/entity/ReviewEntity.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/entity/ReviewEntity.java
@@ -97,6 +97,10 @@ public class ReviewEntity extends BaseEntity {
     @Column(name = "likes_count")
     private Integer likesCount;
 
+    @ColumnDefault("0")
+    @Column(name = "scraps_count")
+    private Integer scrapsCount;
+
     public static ReviewEntity from(Review review) {
         SeatEntity seatEntity =
                 review.getSeat() != null ? SeatEntity.withSeat(review.getSeat()) : null;
@@ -115,7 +119,8 @@ public class ReviewEntity extends BaseEntity {
                         review.getContent(),
                         new ArrayList<>(),
                         new ArrayList<>(),
-                        review.getLikesCount());
+                        review.getLikesCount(),
+                        review.getScrapsCount());
 
         entity.setId(review.getId()); // ID 설정 추가
 
@@ -145,6 +150,7 @@ public class ReviewEntity extends BaseEntity {
                         .dateTime(this.dateTime)
                         .content(this.content)
                         .likesCount(likesCount)
+                        .scrapsCount(scrapsCount)
                         .build();
 
         review.setImages(
@@ -173,5 +179,6 @@ public class ReviewEntity extends BaseEntity {
         dateTime = review.getDateTime();
         content = review.getContent();
         likesCount = review.getLikesCount();
+        scrapsCount = review.getScrapsCount();
     }
 }

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewJpaRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewJpaRepository.java
@@ -44,4 +44,8 @@ public interface ReviewJpaRepository extends JpaRepository<ReviewEntity, Long> {
     @Modifying
     @Query("update ReviewEntity r set r.likesCount = :likesCount where r.id = :id")
     void updateLikesCount(@Param("id") long reviewId, @Param("likesCount") int likesCount);
+
+    @Modifying
+    @Query("update ReviewEntity r set r.scrapsCount = :scrapsCount where r.id = :id")
+    void updateScrapsCount(@Param("id") long reviewId, @Param("scrapsCount") int scrapsCount);
 }

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewRepositoryImpl.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewRepositoryImpl.java
@@ -29,6 +29,11 @@ public class ReviewRepositoryImpl implements ReviewRepository {
     }
 
     @Override
+    public void updateScrapsCount(Long reviewId, int scrapsCount) {
+        reviewJpaRepository.updateScrapsCount(reviewId, scrapsCount);
+    }
+
+    @Override
     public Review save(Review review) {
         ReviewEntity entity = ReviewEntity.from(review);
         ReviewEntity savedEntity = reviewJpaRepository.save(entity);

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/UpdateReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/UpdateReviewUsecase.java
@@ -12,6 +12,8 @@ public interface UpdateReviewUsecase {
 
     void updateLikesCount(Review review);
 
+    void updateScrapsCount(Review review);
+
     @Builder
     record UpdateReviewCommand(
             Long blockId,

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewRepository.java
@@ -10,6 +10,8 @@ import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.LocationInfo;
 public interface ReviewRepository {
     void updateLikesCount(Long reviewId, int likesCount);
 
+    void updateScrapsCount(Long reviewId, int likesCount);
+
     Review save(Review review);
 
     Review findById(Long id);

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/UpdateReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/UpdateReviewService.java
@@ -68,6 +68,11 @@ public class UpdateReviewService implements UpdateReviewUsecase {
         reviewRepository.updateLikesCount(review.getId(), review.getLikesCount());
     }
 
+    @Override
+    public void updateScrapsCount(Review review) {
+        reviewRepository.updateScrapsCount(review.getId(), review.getScrapsCount());
+    }
+
     private Review createUpdatedReview(
             Long reviewId,
             Member member,


### PR DESCRIPTION
## 📌 개요 (필수)

- 스크랩 개수 저장 로직 추가

<br>

## 🔨 작업 사항 (필수)

- [x] 리뷰 엔티티에 scrapsCount 컬럼 추가
- [x] 리뷰 도메인, 응답 객체에 scrapsCount 필드 추가, 매개변수 수정
- [x] scrap controller, service 코드 수정
- [x] scrap repository 코드 업데이트 
- [x] review repository에서 scrapsCount 필드 업데이트하는 메서드 추가

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요.

<br>

## 🌱 연관 내용 (선택)

- @EunjiShin  갓 은 지의 공감 파트 로직이 똑같아 코드를 참고함. (베낌)
- dev와 prod 테이블에 아래의 sql문 적용해서 review 테이블에 scraps_count 컬럼 추가

```sql
alter table reviews add column scraps_count int DEFAULT 0;
```

<br>

## 💻 실행 화면 (필수)

![image](https://github.com/user-attachments/assets/c3819347-21e7-47c8-beb8-5d1bf46673c9)