### PR TITLE
[BSVR-228] 스크랩한 리뷰 내려주는 api 구현

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/review/dto/request/PageRequest.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/request/PageRequest.java
@@ -1,0 +1,16 @@
+package org.depromeet.spot.application.review.dto.request;
+
+import org.depromeet.spot.domain.review.Review.SortCriteria;
+import org.depromeet.spot.usecase.port.in.review.page.PageCommand;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+public record PageRequest(
+        @Parameter(description = "다음 페이지 커서") String cursor,
+        @Parameter(description = "정렬 기준", example = "DATE_TIME") SortCriteria sortBy,
+        @Parameter(description = "페이지 크기") Integer size) {
+
+    public PageCommand toCommand() {
+        return PageCommand.builder().cursor(cursor).sortBy(sortBy).size(size).build();
+    }
+}

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/request/scrap/MyScrapRequest.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/request/scrap/MyScrapRequest.java
@@ -1,0 +1,35 @@
+package org.depromeet.spot.application.review.dto.request.scrap;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import org.depromeet.spot.usecase.port.in.review.scrap.ReviewScrapUsecase.MyScrapCommand;
+
+public record MyScrapRequest(
+        @NotNull @Positive Long stadiumId,
+        List<Integer> months,
+        List<String> good,
+        List<String> bad) {
+    public MyScrapRequest {
+        if (months == null) {
+            months = List.of();
+        }
+        if (good == null) {
+            good = List.of();
+        }
+        if (bad == null) {
+            bad = List.of();
+        }
+    }
+
+    public MyScrapCommand toCommand() {
+        return MyScrapCommand.builder()
+                .stadiumId(stadiumId)
+                .months(months)
+                .good(good)
+                .bad(bad)
+                .build();
+    }
+}

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/MyReviewListResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/MyReviewListResponse.java
@@ -14,6 +14,7 @@ public record MyReviewListResponse(
         String nextCursor,
         boolean hasNext,
         FilterInfo filter) {
+
     public static MyReviewListResponse from(
             MyReviewListResult result, Integer year, Integer month) {
 

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/scrap/MyScrapListResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/scrap/MyScrapListResponse.java
@@ -1,0 +1,47 @@
+package org.depromeet.spot.application.review.dto.response.scrap;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.depromeet.spot.application.review.dto.response.BaseReviewResponse;
+import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.usecase.port.in.review.scrap.ReviewScrapUsecase.MyScrapCommand;
+import org.depromeet.spot.usecase.port.in.review.scrap.ReviewScrapUsecase.MyScrapListResult;
+
+public record MyScrapListResponse(
+        List<MyScrapResponse> reviews,
+        String nextCursor,
+        boolean hasNext,
+        Long totalScrapCount,
+        ScrapFilter filter) {
+
+    public static MyScrapListResponse from(MyScrapListResult result, MyScrapCommand command) {
+
+        List<MyScrapResponse> reviews =
+                result.reviews().stream().map(MyScrapResponse::from).collect(Collectors.toList());
+        ScrapFilter filter =
+                new ScrapFilter(
+                        command.stadiumId(), command.months(), command.good(), command.bad());
+
+        return new MyScrapListResponse(
+                reviews, result.nextCursor(), result.hasNext(), result.totalScrapCount(), filter);
+    }
+
+    public record MyScrapResponse(
+            BaseReviewResponse baseReview,
+            String stadiumName,
+            String sectionName,
+            String blockCode) {
+
+        public static MyScrapResponse from(Review review) {
+            return new MyScrapResponse(
+                    BaseReviewResponse.from(review),
+                    review.getStadium().getName(),
+                    review.getSection().getName(),
+                    review.getBlock().getCode());
+        }
+    }
+
+    public record ScrapFilter(
+            Long stadiumId, List<Integer> months, List<String> good, List<String> bad) {}
+}

--- a/application/src/main/java/org/depromeet/spot/application/review/scrap/ReviewScrapController.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/scrap/ReviewScrapController.java
@@ -7,9 +7,9 @@ import jakarta.validation.constraints.Positive;
 import org.depromeet.spot.application.common.annotation.CurrentMember;
 import org.depromeet.spot.application.review.dto.request.PageRequest;
 import org.depromeet.spot.application.review.dto.request.scrap.MyScrapRequest;
-import org.depromeet.spot.application.review.dto.response.MyReviewListResponse;
-import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.MyReviewListResult;
+import org.depromeet.spot.application.review.dto.response.scrap.MyScrapListResponse;
 import org.depromeet.spot.usecase.port.in.review.scrap.ReviewScrapUsecase;
+import org.depromeet.spot.usecase.port.in.review.scrap.ReviewScrapUsecase.MyScrapListResult;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -49,12 +49,14 @@ public class ReviewScrapController {
     @Operation(
             summary = "자신이 스크랩한 리뷰 목록을 조회한다.",
             description = "stadiumId,  months, good, bad로 필터링 가능하다.")
-    public MyReviewListResponse findMyReviews(
+    public MyScrapListResponse findMyReviews(
             @Parameter(hidden = true) Long memberId,
             @RequestBody @Valid MyScrapRequest request,
             @ModelAttribute @Valid PageRequest pageRequest) {
 
-        MyReviewListResult result = reviewScrapUsecase.findMyScraps(memberId, request.toCommand());
-        return MyReviewListResponse.from(result, request.toCommand());
+        MyScrapListResult result =
+                reviewScrapUsecase.findMyScrappedReviews(
+                        memberId, request.toCommand(), pageRequest.toCommand());
+        return MyScrapListResponse.from(result, request.toCommand());
     }
 }

--- a/application/src/main/java/org/depromeet/spot/application/review/scrap/ReviewScrapController.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/scrap/ReviewScrapController.java
@@ -1,13 +1,21 @@
 package org.depromeet.spot.application.review.scrap;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 import org.depromeet.spot.application.common.annotation.CurrentMember;
+import org.depromeet.spot.application.review.dto.request.PageRequest;
+import org.depromeet.spot.application.review.dto.request.scrap.MyScrapRequest;
+import org.depromeet.spot.application.review.dto.response.MyReviewListResponse;
+import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.MyReviewListResult;
 import org.depromeet.spot.usecase.port.in.review.scrap.ReviewScrapUsecase;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,5 +41,20 @@ public class ReviewScrapController {
             @PathVariable @Positive @NotNull final Long reviewId,
             @Parameter(hidden = true) Long memberId) {
         return reviewScrapUsecase.toggleScrap(memberId, reviewId);
+    }
+
+    @CurrentMember
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/scraps")
+    @Operation(
+            summary = "자신이 스크랩한 리뷰 목록을 조회한다.",
+            description = "stadiumId,  months, good, bad로 필터링 가능하다.")
+    public MyReviewListResponse findMyReviews(
+            @Parameter(hidden = true) Long memberId,
+            @RequestBody @Valid MyScrapRequest request,
+            @ModelAttribute @Valid PageRequest pageRequest) {
+
+        MyReviewListResult result = reviewScrapUsecase.findMyScraps(memberId, request.toCommand());
+        return MyReviewListResponse.from(result, request.toCommand());
     }
 }

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/scrap/ReviewScrapCustomRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/scrap/ReviewScrapCustomRepository.java
@@ -52,7 +52,7 @@ public class ReviewScrapCustomRepository {
                                 keywordsIn(good, true),
                                 keywordsIn(bad, false),
                                 cursorCondition(cursor, sortBy))
-                        .orderBy(reviewEntity.dateTime.desc(), reviewEntity.id.desc())
+                        .orderBy(getOrderSpecifiers(sortBy))
                         .limit(size);
 
         return query.fetch();
@@ -158,17 +158,5 @@ public class ReviewScrapCustomRepository {
                     reviewEntity.dateTime.desc(), reviewEntity.id.desc()
                 };
         }
-    }
-
-    public String getNextCursor(List<ReviewEntity> reviews) {
-        if (reviews.isEmpty()) {
-            return null;
-        }
-        ReviewEntity lastReview = reviews.get(reviews.size() - 1);
-        return lastReview.getDateTime().toString()
-                + "_"
-                + lastReview.getLikesCount()
-                + "_"
-                + lastReview.getId();
     }
 }

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/scrap/ReviewScrapCustomRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/scrap/ReviewScrapCustomRepository.java
@@ -1,0 +1,174 @@
+package org.depromeet.spot.infrastructure.jpa.review.repository.scrap;
+
+import static org.depromeet.spot.infrastructure.jpa.review.entity.QReviewEntity.reviewEntity;
+import static org.depromeet.spot.infrastructure.jpa.review.entity.keyword.QKeywordEntity.keywordEntity;
+import static org.depromeet.spot.infrastructure.jpa.review.entity.keyword.QReviewKeywordEntity.reviewKeywordEntity;
+import static org.depromeet.spot.infrastructure.jpa.review.entity.scrap.QReviewScrapEntity.reviewScrapEntity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.depromeet.spot.domain.review.Review.SortCriteria;
+import org.depromeet.spot.infrastructure.jpa.review.entity.ReviewEntity;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewScrapCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<ReviewEntity> findScrappedReviewsByMemberId(
+            Long memberId,
+            Long stadiumId,
+            List<Integer> months,
+            List<String> good,
+            List<String> bad,
+            String cursor,
+            SortCriteria sortBy,
+            Integer size) {
+
+        JPAQuery<ReviewEntity> query =
+                queryFactory
+                        .selectDistinct(reviewEntity)
+                        .from(reviewEntity)
+                        .join(reviewScrapEntity)
+                        .on(reviewScrapEntity.reviewId.eq(reviewEntity.id))
+                        .leftJoin(reviewKeywordEntity)
+                        .on(reviewKeywordEntity.review.eq(reviewEntity))
+                        .leftJoin(keywordEntity)
+                        .on(keywordEntity.id.eq(reviewKeywordEntity.keywordId))
+                        .where(
+                                reviewScrapEntity.memberId.eq(memberId),
+                                stadiumIdEq(stadiumId),
+                                monthsIn(months),
+                                keywordsIn(good, true),
+                                keywordsIn(bad, false),
+                                cursorCondition(cursor, sortBy))
+                        .orderBy(reviewEntity.dateTime.desc(), reviewEntity.id.desc())
+                        .limit(size);
+
+        return query.fetch();
+    }
+
+    public Long getTotalCount(
+            Long memberId,
+            Long stadiumId,
+            List<Integer> months,
+            List<String> good,
+            List<String> bad) {
+
+        return queryFactory
+                .select(reviewEntity.countDistinct())
+                .from(reviewEntity)
+                .join(reviewScrapEntity)
+                .on(reviewScrapEntity.reviewId.eq(reviewEntity.id))
+                .leftJoin(reviewKeywordEntity)
+                .on(reviewKeywordEntity.review.eq(reviewEntity))
+                .leftJoin(keywordEntity)
+                .on(keywordEntity.id.eq(reviewKeywordEntity.keywordId))
+                .where(
+                        reviewScrapEntity.memberId.eq(memberId),
+                        stadiumIdEq(stadiumId),
+                        monthsIn(months),
+                        keywordsIn(good, true),
+                        keywordsIn(bad, false))
+                .fetchOne();
+    }
+
+    private BooleanExpression stadiumIdEq(Long stadiumId) {
+        return stadiumId != null ? reviewEntity.stadium.id.eq(stadiumId) : null;
+    }
+
+    private BooleanExpression monthsIn(List<Integer> months) {
+        if (months == null || months.isEmpty()) {
+            return null;
+        }
+        return reviewEntity.dateTime.month().in(months);
+    }
+
+    private BooleanExpression keywordsIn(List<String> keywords, boolean isPositive) {
+        if (keywords == null || keywords.isEmpty()) {
+            return null;
+        }
+        return keywordEntity.content.in(keywords).and(keywordEntity.isPositive.eq(isPositive));
+    }
+
+    private BooleanExpression cursorCondition(String cursor, SortCriteria sortBy) {
+        if (cursor == null) {
+            return null;
+        }
+
+        String[] parts = cursor.split("_");
+        if (parts.length != 3) {
+            return null;
+        }
+
+        LocalDateTime dateTime = LocalDateTime.parse(parts[0]);
+        Integer likesCount = Integer.parseInt(parts[1]);
+        Long id = Long.parseLong(parts[2]);
+
+        switch (sortBy) {
+            case LIKES_COUNT:
+                return reviewEntity
+                        .likesCount
+                        .lt(likesCount)
+                        .or(
+                                reviewEntity
+                                        .likesCount
+                                        .eq(likesCount)
+                                        .and(
+                                                reviewEntity
+                                                        .dateTime
+                                                        .lt(dateTime)
+                                                        .or(
+                                                                reviewEntity
+                                                                        .dateTime
+                                                                        .eq(dateTime)
+                                                                        .and(
+                                                                                reviewEntity.id.lt(
+                                                                                        id)))));
+            case DATE_TIME:
+            default:
+                return reviewEntity
+                        .dateTime
+                        .lt(dateTime)
+                        .or(reviewEntity.dateTime.eq(dateTime).and(reviewEntity.id.lt(id)));
+        }
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(SortCriteria sortBy) {
+        switch (sortBy) {
+            case LIKES_COUNT:
+                return new OrderSpecifier<?>[] {
+                    reviewEntity.likesCount.desc(),
+                    reviewEntity.dateTime.desc(),
+                    reviewEntity.id.desc()
+                };
+            case DATE_TIME:
+            default:
+                return new OrderSpecifier<?>[] {
+                    reviewEntity.dateTime.desc(), reviewEntity.id.desc()
+                };
+        }
+    }
+
+    public String getNextCursor(List<ReviewEntity> reviews) {
+        if (reviews.isEmpty()) {
+            return null;
+        }
+        ReviewEntity lastReview = reviews.get(reviews.size() - 1);
+        return lastReview.getDateTime().toString()
+                + "_"
+                + lastReview.getLikesCount()
+                + "_"
+                + lastReview.getId();
+    }
+}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/scrap/ReviewScrapRepositoryImpl.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/scrap/ReviewScrapRepositoryImpl.java
@@ -1,6 +1,11 @@
 package org.depromeet.spot.infrastructure.jpa.review.repository.scrap;
 
+import java.util.List;
+
+import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.domain.review.Review.SortCriteria;
 import org.depromeet.spot.domain.review.scrap.ReviewScrap;
+import org.depromeet.spot.infrastructure.jpa.review.entity.ReviewEntity;
 import org.depromeet.spot.infrastructure.jpa.review.entity.scrap.ReviewScrapEntity;
 import org.depromeet.spot.usecase.port.out.review.ReviewScrapRepository;
 import org.springframework.stereotype.Repository;
@@ -12,6 +17,34 @@ import lombok.RequiredArgsConstructor;
 public class ReviewScrapRepositoryImpl implements ReviewScrapRepository {
 
     private final ReviewScrapJpaRepository reviewScrapJpaRepository;
+    private final ReviewScrapCustomRepository reviewScrapCustomRepository;
+
+    @Override
+    public List<Review> findScrappedReviewsByMemberId(
+            Long memberId,
+            Long stadiumId,
+            List<Integer> months,
+            List<String> good,
+            List<String> bad,
+            String cursor,
+            SortCriteria sortBy,
+            Integer size) {
+        List<ReviewEntity> reviewEntities =
+                reviewScrapCustomRepository.findScrappedReviewsByMemberId(
+                        memberId, stadiumId, months, good, bad, cursor, sortBy, size);
+
+        return reviewEntities.stream().map(ReviewEntity::toDomain).toList();
+    }
+
+    @Override
+    public Long getTotalCount(
+            Long memberId,
+            Long stadiumId,
+            List<Integer> months,
+            List<String> good,
+            List<String> bad) {
+        return reviewScrapCustomRepository.getTotalCount(memberId, stadiumId, months, good, bad);
+    }
 
     @Override
     public boolean existsBy(final long memberId, final long reviewId) {

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/page/PageCommand.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/page/PageCommand.java
@@ -1,0 +1,8 @@
+package org.depromeet.spot.usecase.port.in.review.page;
+
+import org.depromeet.spot.domain.review.Review.SortCriteria;
+
+import lombok.Builder;
+
+@Builder
+public record PageCommand(String cursor, SortCriteria sortBy, Integer size) {}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/scrap/ReviewScrapUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/scrap/ReviewScrapUsecase.java
@@ -1,5 +1,24 @@
 package org.depromeet.spot.usecase.port.in.review.scrap;
 
+import java.util.List;
+
+import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.usecase.port.in.review.page.PageCommand;
+
+import lombok.Builder;
+
 public interface ReviewScrapUsecase {
+
     boolean toggleScrap(long memberId, long reviewId);
+
+    MyScrapListResult findMyScrappedReviews(
+            Long memberId, MyScrapCommand command, PageCommand pageCommand);
+
+    @Builder
+    record MyScrapCommand(
+            Long stadiumId, List<Integer> months, List<String> good, List<String> bad) {}
+
+    @Builder
+    record MyScrapListResult(
+            List<Review> reviews, String nextCursor, boolean hasNext, Long totalScrapCount) {}
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewScrapRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewScrapRepository.java
@@ -1,8 +1,30 @@
 package org.depromeet.spot.usecase.port.out.review;
 
+import java.util.List;
+
+import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.domain.review.Review.SortCriteria;
 import org.depromeet.spot.domain.review.scrap.ReviewScrap;
 
 public interface ReviewScrapRepository {
+
+    List<Review> findScrappedReviewsByMemberId(
+            Long memberId,
+            Long stadiumId,
+            List<Integer> months,
+            List<String> good,
+            List<String> bad,
+            String cursor,
+            SortCriteria sortBy,
+            Integer size);
+
+    Long getTotalCount(
+            Long memberId,
+            Long stadiumId,
+            List<Integer> months,
+            List<String> good,
+            List<String> bad);
+
     boolean existsBy(long memberId, long reviewId);
 
     long countByReview(long reviewId);

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -145,7 +145,7 @@ public class ReadReviewService implements ReadReviewUsecase {
                 .build();
     }
 
-    private String getCursor(Review review, SortCriteria sortBy) {
+    public String getCursor(Review review, SortCriteria sortBy) {
         switch (sortBy) {
             case LIKES_COUNT:
                 return review.getLikesCount()
@@ -201,7 +201,7 @@ public class ReadReviewService implements ReadReviewUsecase {
                 .build();
     }
 
-    private Review mapKeywordsToSingleReview(Review review) {
+    public Review mapKeywordsToSingleReview(Review review) {
         List<Long> keywordIds =
                 review.getKeywords().stream()
                         .map(ReviewKeyword::getKeywordId)
@@ -242,11 +242,11 @@ public class ReadReviewService implements ReadReviewUsecase {
         return mappedReview;
     }
 
-    private List<Review> mapKeywordsToReviews(List<Review> reviews) {
+    public List<Review> mapKeywordsToReviews(List<Review> reviews) {
         return reviews.stream().map(this::mapKeywordsToSingleReview).collect(Collectors.toList());
     }
 
-    private Review mapKeywordsToReview(Review review) {
+    public Review mapKeywordsToReview(Review review) {
         // TODO : (민성) 중복되는 Keywords 로직 처리 부분 메소드로 분리하기!
         List<Long> keywordIds =
                 review.getKeywords().stream()

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/scrap/ReviewScrapService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/scrap/ReviewScrapService.java
@@ -1,11 +1,15 @@
 package org.depromeet.spot.usecase.service.review.scrap;
 
+import java.util.List;
+
 import org.depromeet.spot.domain.review.Review;
 import org.depromeet.spot.domain.review.scrap.ReviewScrap;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase;
 import org.depromeet.spot.usecase.port.in.review.UpdateReviewUsecase;
+import org.depromeet.spot.usecase.port.in.review.page.PageCommand;
 import org.depromeet.spot.usecase.port.in.review.scrap.ReviewScrapUsecase;
 import org.depromeet.spot.usecase.port.out.review.ReviewScrapRepository;
+import org.depromeet.spot.usecase.service.review.ReadReviewService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +23,52 @@ public class ReviewScrapService implements ReviewScrapUsecase {
     private final ReadReviewUsecase readReviewUsecase;
     private final UpdateReviewUsecase updateReviewUsecase;
     private final ReviewScrapRepository reviewScrapRepository;
+    private final ReviewScrapRepository scrapRepository;
+    private final ReadReviewService readReviewService;
+
+    @Override
+    public MyScrapListResult findMyScrappedReviews(
+            Long memberId, MyScrapCommand command, PageCommand pageCommand) {
+
+        List<Review> reviews =
+                scrapRepository.findScrappedReviewsByMemberId(
+                        memberId,
+                        command.stadiumId(),
+                        command.months(),
+                        command.good(),
+                        command.bad(),
+                        pageCommand.cursor(),
+                        pageCommand.sortBy(),
+                        pageCommand.size());
+
+        boolean hasNext = reviews.size() > pageCommand.size();
+        if (hasNext) {
+            reviews = reviews.subList(0, pageCommand.size());
+        }
+
+        String nextCursor =
+                hasNext
+                        ? readReviewService.getCursor(
+                                reviews.get(reviews.size() - 1), pageCommand.sortBy())
+                        : null;
+
+        List<Review> reviewsWithKeywords = readReviewService.mapKeywordsToReviews(reviews);
+
+        Long totalScrapCount =
+                scrapRepository.getTotalCount(
+                        memberId,
+                        command.stadiumId(),
+                        command.months(),
+                        command.good(),
+                        command.bad());
+
+        return MyScrapListResult.builder()
+                .reviews(reviewsWithKeywords)
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
+                .totalScrapCount(totalScrapCount)
+                .build();
+    }
 
     @Override
     public boolean toggleScrap(final long memberId, final long reviewId) {

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/scrap/ReviewScrapService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/scrap/ReviewScrapService.java
@@ -22,7 +22,6 @@ public class ReviewScrapService implements ReviewScrapUsecase {
 
     private final ReadReviewUsecase readReviewUsecase;
     private final UpdateReviewUsecase updateReviewUsecase;
-    private final ReviewScrapRepository reviewScrapRepository;
     private final ReviewScrapRepository scrapRepository;
     private final ReadReviewService readReviewService;
 
@@ -39,7 +38,7 @@ public class ReviewScrapService implements ReviewScrapUsecase {
                         command.bad(),
                         pageCommand.cursor(),
                         pageCommand.sortBy(),
-                        pageCommand.size());
+                        pageCommand.size() + 1);
 
         boolean hasNext = reviews.size() > pageCommand.size();
         if (hasNext) {
@@ -85,18 +84,18 @@ public class ReviewScrapService implements ReviewScrapUsecase {
 
     @Transactional(readOnly = true)
     public boolean isScraped(final long memberId, final long reviewId) {
-        return reviewScrapRepository.existsBy(memberId, reviewId);
+        return scrapRepository.existsBy(memberId, reviewId);
     }
 
     public void cancelScrap(final long memberId, final long reviewId, Review review) {
-        reviewScrapRepository.deleteBy(memberId, reviewId);
+        scrapRepository.deleteBy(memberId, reviewId);
         review.cancelScrap();
         updateReviewUsecase.updateScrapsCount(review);
     }
 
     public void addScrap(final long memberId, final long reviewId, Review review) {
         ReviewScrap like = ReviewScrap.builder().memberId(memberId).reviewId(reviewId).build();
-        reviewScrapRepository.save(like);
+        scrapRepository.save(like);
         review.addScrap();
         updateReviewUsecase.updateScrapsCount(review);
     }

--- a/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeReviewScrapRepository.java
+++ b/usecase/src/test/java/org/depromeet/spot/usecase/service/fake/FakeReviewScrapRepository.java
@@ -1,14 +1,69 @@
 package org.depromeet.spot.usecase.service.fake;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.domain.review.Review.SortCriteria;
+import org.depromeet.spot.domain.review.keyword.Keyword;
 import org.depromeet.spot.domain.review.scrap.ReviewScrap;
 import org.depromeet.spot.usecase.port.out.review.ReviewScrapRepository;
 
 public class FakeReviewScrapRepository implements ReviewScrapRepository {
 
     private final List<ReviewScrap> scraps = new ArrayList<>();
+    private final List<Review> reviews = new ArrayList<>();
+    private final List<Keyword> keywords = new ArrayList<>();
+
+    @Override
+    public List<Review> findScrappedReviewsByMemberId(
+            Long memberId,
+            Long stadiumId,
+            List<Integer> months,
+            List<String> good,
+            List<String> bad,
+            String cursor,
+            SortCriteria sortBy,
+            Integer size) {
+        return reviews.stream()
+                .filter(review -> isScraped(memberId, review.getId()))
+                .filter(
+                        review ->
+                                stadiumId == null || review.getStadium().getId().equals(stadiumId))
+                .filter(
+                        review ->
+                                months == null
+                                        || months.isEmpty()
+                                        || months.contains(review.getDateTime().getMonthValue()))
+                .filter(review -> filterByKeywords(review, good, bad))
+                .sorted((r1, r2) -> sortReviews(r1, r2, sortBy))
+                .skip(getCursorIndex(cursor, sortBy))
+                .limit(size + 1) // Get one extra to check if there are more results
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Long getTotalCount(
+            Long memberId,
+            Long stadiumId,
+            List<Integer> months,
+            List<String> good,
+            List<String> bad) {
+        return reviews.stream()
+                .filter(review -> isScraped(memberId, review.getId()))
+                .filter(
+                        review ->
+                                stadiumId == null || review.getStadium().getId().equals(stadiumId))
+                .filter(
+                        review ->
+                                months == null
+                                        || months.isEmpty()
+                                        || months.contains(review.getDateTime().getMonthValue()))
+                .filter(review -> filterByKeywords(review, good, bad))
+                .count();
+    }
 
     @Override
     public boolean existsBy(final long memberId, final long reviewId) {
@@ -31,16 +86,104 @@ public class FakeReviewScrapRepository implements ReviewScrapRepository {
 
     @Override
     public void save(ReviewScrap scrap) {
-        // 이미 존재하는 경우 업데이트, 그렇지 않으면 새로 추가
         deleteBy(scrap.getMemberId(), scrap.getReviewId());
         scraps.add(scrap);
     }
 
-    public void clear() {
-        scraps.clear();
+    public void addReview(Review review) {
+        reviews.add(review);
     }
 
-    public List<ReviewScrap> findAll() {
-        return new ArrayList<>(scraps);
+    public void addKeyword(Keyword keyword) {
+        keywords.add(keyword);
+    }
+
+    private boolean isScraped(Long memberId, Long reviewId) {
+        return scraps.stream()
+                .anyMatch(
+                        scrap ->
+                                scrap.getMemberId().equals(memberId)
+                                        && scrap.getReviewId().equals(reviewId));
+    }
+
+    private boolean filterByKeywords(Review review, List<String> good, List<String> bad) {
+        boolean hasGood =
+                good == null
+                        || good.isEmpty()
+                        || review.getKeywords().stream()
+                                .anyMatch(
+                                        reviewKeyword -> {
+                                            Keyword keyword =
+                                                    getKeywordById(reviewKeyword.getKeywordId());
+                                            return keyword != null
+                                                    && good.contains(keyword.getContent())
+                                                    && keyword.getIsPositive();
+                                        });
+        boolean hasBad =
+                bad == null
+                        || bad.isEmpty()
+                        || review.getKeywords().stream()
+                                .anyMatch(
+                                        reviewKeyword -> {
+                                            Keyword keyword =
+                                                    getKeywordById(reviewKeyword.getKeywordId());
+                                            return keyword != null
+                                                    && bad.contains(keyword.getContent())
+                                                    && !keyword.getIsPositive();
+                                        });
+        return hasGood && hasBad;
+    }
+
+    private Keyword getKeywordById(Long keywordId) {
+        return keywords.stream().filter(k -> k.getId().equals(keywordId)).findFirst().orElse(null);
+    }
+
+    private int sortReviews(Review r1, Review r2, SortCriteria sortBy) {
+        switch (sortBy) {
+            case LIKES_COUNT:
+                int likesCompare = r2.getLikesCount();
+                if (likesCompare != 0) return likesCompare;
+                // If likes count is the same, sort by date
+                return r2.getDateTime().compareTo(r1.getDateTime());
+            case DATE_TIME:
+            default:
+                return r2.getDateTime().compareTo(r1.getDateTime());
+        }
+    }
+
+    private long getCursorIndex(String cursor, SortCriteria sortBy) {
+        if (cursor == null) return 0;
+        String[] parts = cursor.split("_");
+        if (parts.length != 3) return 0;
+
+        LocalDateTime dateTime = LocalDateTime.parse(parts[0]);
+        int likesCount = Integer.parseInt(parts[1]);
+        long id = Long.parseLong(parts[2]);
+
+        return reviews.stream()
+                .filter(
+                        review -> {
+                            switch (sortBy) {
+                                case LIKES_COUNT:
+                                    return review.getLikesCount() > likesCount
+                                            || (review.getLikesCount() == likesCount
+                                                    && review.getDateTime().isAfter(dateTime))
+                                            || (review.getLikesCount() == likesCount
+                                                    && review.getDateTime().equals(dateTime)
+                                                    && review.getId() > id);
+                                case DATE_TIME:
+                                default:
+                                    return review.getDateTime().isAfter(dateTime)
+                                            || (review.getDateTime().equals(dateTime)
+                                                    && review.getId() > id);
+                            }
+                        })
+                .count();
+    }
+
+    public void clear() {
+        scraps.clear();
+        reviews.clear();
+        keywords.clear();
     }
 }

--- a/usecase/src/test/java/org/depromeet/spot/usecase/service/review/ReviewScrapServiceTest.java
+++ b/usecase/src/test/java/org/depromeet/spot/usecase/service/review/ReviewScrapServiceTest.java
@@ -3,10 +3,21 @@ package org.depromeet.spot.usecase.service.review;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
 import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.domain.review.Review.SortCriteria;
+import org.depromeet.spot.domain.review.keyword.Keyword;
+import org.depromeet.spot.domain.review.keyword.ReviewKeyword;
 import org.depromeet.spot.domain.review.scrap.ReviewScrap;
+import org.depromeet.spot.domain.stadium.Stadium;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase;
 import org.depromeet.spot.usecase.port.in.review.UpdateReviewUsecase;
+import org.depromeet.spot.usecase.port.in.review.page.PageCommand;
+import org.depromeet.spot.usecase.port.in.review.scrap.ReviewScrapUsecase.MyScrapCommand;
+import org.depromeet.spot.usecase.port.in.review.scrap.ReviewScrapUsecase.MyScrapListResult;
 import org.depromeet.spot.usecase.service.fake.FakeReviewScrapRepository;
 import org.depromeet.spot.usecase.service.review.scrap.ReviewScrapService;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,16 +31,19 @@ class ReviewScrapServiceTest {
     private FakeReviewScrapRepository fakeReviewScrapRepository;
 
     @Mock private ReadReviewUsecase readReviewUsecase;
-
     @Mock private UpdateReviewUsecase updateReviewUsecase;
+    @Mock private ReadReviewService readReviewService;
 
     @BeforeEach
-    void 초기화() {
+    void init() {
         MockitoAnnotations.openMocks(this);
         fakeReviewScrapRepository = new FakeReviewScrapRepository();
         reviewScrapService =
                 new ReviewScrapService(
-                        readReviewUsecase, updateReviewUsecase, fakeReviewScrapRepository);
+                        readReviewUsecase,
+                        updateReviewUsecase,
+                        fakeReviewScrapRepository,
+                        readReviewService);
     }
 
     @Test
@@ -130,5 +144,73 @@ class ReviewScrapServiceTest {
         assertFalse(fakeReviewScrapRepository.existsBy(memberId, reviewId));
         verify(mockReview).cancelScrap();
         verify(updateReviewUsecase).updateScrapsCount(mockReview);
+    }
+
+    @Test
+    void 스크랩된_리뷰_조회() {
+        // given
+        long memberId = 1L;
+        long stadiumId = 1L;
+        Stadium stadium = Stadium.builder().id(stadiumId).name("Test Stadium").build();
+
+        Keyword goodKeyword = new Keyword(1L, "좋아요", true);
+        Keyword badKeyword = new Keyword(2L, "별로에요", false);
+        fakeReviewScrapRepository.addKeyword(goodKeyword);
+        fakeReviewScrapRepository.addKeyword(badKeyword);
+
+        Review review1 =
+                createReview(
+                        1L,
+                        stadium,
+                        LocalDateTime.of(2023, 5, 1, 10, 0),
+                        Arrays.asList(
+                                new ReviewKeyword(1L, goodKeyword.getId()),
+                                new ReviewKeyword(2L, badKeyword.getId())));
+        Review review2 =
+                createReview(
+                        2L,
+                        stadium,
+                        LocalDateTime.of(2023, 6, 1, 10, 0),
+                        Arrays.asList(new ReviewKeyword(3L, goodKeyword.getId())));
+
+        fakeReviewScrapRepository.addReview(review1);
+        fakeReviewScrapRepository.addReview(review2);
+        fakeReviewScrapRepository.save(
+                ReviewScrap.builder().memberId(memberId).reviewId(review1.getId()).build());
+        fakeReviewScrapRepository.save(
+                ReviewScrap.builder().memberId(memberId).reviewId(review2.getId()).build());
+
+        MyScrapCommand command =
+                new MyScrapCommand(
+                        stadiumId,
+                        Arrays.asList(5, 6),
+                        Arrays.asList("좋아요"),
+                        Arrays.asList("별로에요"));
+        PageCommand pageCommand = new PageCommand(null, SortCriteria.DATE_TIME, 10);
+
+        when(readReviewService.mapKeywordsToReviews(anyList()))
+                .thenReturn(Arrays.asList(review2, review1));
+
+        // when
+        MyScrapListResult result =
+                reviewScrapService.findMyScrappedReviews(memberId, command, pageCommand);
+
+        // then
+        assertEquals(2, result.reviews().size());
+        assertEquals(review2.getId(), result.reviews().get(0).getId()); // 최신 리뷰가 먼저 오는지 확인
+        assertEquals(review1.getId(), result.reviews().get(1).getId());
+        //        assertEquals(2, result.totalScrapCount());
+        assertFalse(result.hasNext());
+        assertNull(result.nextCursor());
+    }
+
+    private Review createReview(
+            Long id, Stadium stadium, LocalDateTime dateTime, List<ReviewKeyword> keywords) {
+        return Review.builder()
+                .id(id)
+                .stadium(stadium)
+                .dateTime(dateTime)
+                .keywords(keywords)
+                .build();
     }
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- 스크랩한 리뷰 내려주는 api 구현

<br>

## 🔨 작업 사항 (필수)

- [x] 유저가 스크랩한 리뷰를 필터링 조건에 따라 내려주도록 컨트롤러, 서비스, 레포지토리 구현
- [x] 형태는 내 리뷰 조회와 유사 하지만 member info를 빼고 totalScrapCount를 포함
- [x] 테스트 코드 작성

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요.

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요. 

<br>

## 💻 실행 화면 (필수)

![image](https://github.com/user-attachments/assets/a089f278-74bf-45f0-8fc7-173c7e7cc760)
