### PR TITLE
[BSVR-229] 등록 플로우 시야 후기, 직관 후기 분리 

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/review/dto/request/CreateReviewRequest.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/request/CreateReviewRequest.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.Size;
 
 import org.depromeet.spot.common.exception.review.ReviewException.InvalidReviewDateTimeFormatException;
 import org.depromeet.spot.common.exception.review.ReviewException.InvalidReviewKeywordsException;
+import org.depromeet.spot.domain.review.Review.ReviewType;
 import org.depromeet.spot.usecase.port.in.review.CreateReviewUsecase.CreateReviewCommand;
 
 public record CreateReviewRequest(
@@ -20,7 +21,8 @@ public record CreateReviewRequest(
         List<String> good,
         List<String> bad,
         String content,
-        @NotNull String dateTime) {
+        @NotNull String dateTime,
+        ReviewType reviewType) {
 
     public CreateReviewCommand toCommand() {
         validateGoodAndBad();
@@ -32,6 +34,7 @@ public record CreateReviewRequest(
                 .bad(bad)
                 .content(content)
                 .dateTime(toLocalDateTime(dateTime))
+                .reviewType(reviewType)
                 .build();
     }
 

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/BaseReviewResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/BaseReviewResponse.java
@@ -8,6 +8,7 @@ import org.depromeet.spot.domain.block.Block;
 import org.depromeet.spot.domain.block.BlockRow;
 import org.depromeet.spot.domain.member.Member;
 import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.domain.review.Review.ReviewType;
 import org.depromeet.spot.domain.review.keyword.Keyword;
 import org.depromeet.spot.domain.seat.Seat;
 import org.depromeet.spot.domain.section.Section;
@@ -27,7 +28,8 @@ public record BaseReviewResponse(
         List<ReviewImageResponse> images,
         List<KeywordResponse> keywords,
         int likesCount,
-        int scrapsCount) {
+        int scrapsCount,
+        ReviewType reviewType) {
 
     public static BaseReviewResponse from(CreateReviewResult result) {
         Review review = result.review();
@@ -56,7 +58,8 @@ public record BaseReviewResponse(
                                 })
                         .toList(),
                 review.getLikesCount(),
-                review.getScrapsCount());
+                review.getScrapsCount(),
+                review.getReviewType());
     }
 
     public static BaseReviewResponse from(Review review) {
@@ -85,7 +88,8 @@ public record BaseReviewResponse(
                                 })
                         .collect(Collectors.toList()),
                 review.getLikesCount(),
-                review.getScrapsCount());
+                review.getScrapsCount(),
+                review.getReviewType());
     }
 
     public record StadiumResponse(Long id, String name) {

--- a/domain/src/main/java/org/depromeet/spot/domain/review/Review.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/review/Review.java
@@ -22,6 +22,16 @@ import lombok.Getter;
 @Getter
 public class Review {
 
+    public enum ReviewType {
+        VIEW, // 시야 후기
+        FEED, // 직관 후기
+    }
+
+    public enum SortCriteria {
+        DATE_TIME,
+        LIKES_COUNT,
+    }
+
     private final Long id;
     private final Member member;
     private final Stadium stadium;
@@ -37,6 +47,7 @@ public class Review {
     private transient Map<Long, Keyword> keywordMap;
     private int likesCount;
     private int scrapsCount;
+    private ReviewType reviewType;
 
     public static final int DEFAULT_LIKE_COUNT = 0;
 
@@ -55,7 +66,8 @@ public class Review {
             List<ReviewImage> images,
             List<ReviewKeyword> keywords,
             int likesCount,
-            int scrapsCount) {
+            int scrapsCount,
+            ReviewType reviewType) {
         if (likesCount < 0) {
             throw new InvalidReviewLikesException();
         }
@@ -74,6 +86,7 @@ public class Review {
         this.keywords = keywords != null ? keywords : new ArrayList<>();
         this.likesCount = likesCount;
         this.scrapsCount = scrapsCount;
+        this.reviewType = reviewType;
     }
 
     public void addKeyword(ReviewKeyword keyword) {
@@ -125,10 +138,5 @@ public class Review {
 
     public void setDeletedAt(LocalDateTime now) {
         this.deletedAt = now;
-    }
-
-    public enum SortCriteria {
-        DATE_TIME,
-        LIKES_COUNT,
     }
 }

--- a/domain/src/main/java/org/depromeet/spot/domain/review/Review.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/review/Review.java
@@ -47,9 +47,10 @@ public class Review {
     private transient Map<Long, Keyword> keywordMap;
     private int likesCount;
     private int scrapsCount;
-    private ReviewType reviewType;
+    private final ReviewType reviewType;
 
     public static final int DEFAULT_LIKE_COUNT = 0;
+    public static final int DEFAULT_SCRAPS_COUNT = 0;
 
     @Builder
     public Review(

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/entity/ReviewEntity.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/entity/ReviewEntity.java
@@ -9,6 +9,8 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.JoinColumn;
@@ -17,6 +19,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.domain.review.Review.ReviewType;
 import org.depromeet.spot.infrastructure.jpa.block.entity.BlockEntity;
 import org.depromeet.spot.infrastructure.jpa.block.entity.BlockRowEntity;
 import org.depromeet.spot.infrastructure.jpa.common.entity.BaseEntity;
@@ -101,6 +104,10 @@ public class ReviewEntity extends BaseEntity {
     @Column(name = "scraps_count")
     private Integer scrapsCount;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "review_type", nullable = false)
+    private ReviewType reviewType;
+
     public static ReviewEntity from(Review review) {
         SeatEntity seatEntity =
                 review.getSeat() != null ? SeatEntity.withSeat(review.getSeat()) : null;
@@ -120,7 +127,8 @@ public class ReviewEntity extends BaseEntity {
                         new ArrayList<>(),
                         new ArrayList<>(),
                         review.getLikesCount(),
-                        review.getScrapsCount());
+                        review.getScrapsCount(),
+                        review.getReviewType());
 
         entity.setId(review.getId()); // ID 설정 추가
 
@@ -151,6 +159,7 @@ public class ReviewEntity extends BaseEntity {
                         .content(this.content)
                         .likesCount(likesCount)
                         .scrapsCount(scrapsCount)
+                        .reviewType(reviewType)
                         .build();
 
         review.setImages(
@@ -180,5 +189,6 @@ public class ReviewEntity extends BaseEntity {
         content = review.getContent();
         likesCount = review.getLikesCount();
         scrapsCount = review.getScrapsCount();
+        reviewType = review.getReviewType();
     }
 }

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/entity/ReviewEntity.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/entity/ReviewEntity.java
@@ -105,6 +105,7 @@ public class ReviewEntity extends BaseEntity {
     private Integer scrapsCount;
 
     @Enumerated(EnumType.STRING)
+    @ColumnDefault("VIEW")
     @Column(name = "review_type", nullable = false)
     private ReviewType reviewType;
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/CreateReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/CreateReviewUsecase.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.depromeet.spot.domain.member.Member;
 import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.domain.review.Review.ReviewType;
 import org.depromeet.spot.domain.seat.Seat;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -28,7 +29,8 @@ public interface CreateReviewUsecase {
             List<String> good,
             List<String> bad,
             String content,
-            LocalDateTime dateTime) {}
+            LocalDateTime dateTime,
+            ReviewType reviewType) {}
 
     @Builder
     record CreateAdminReviewCommand(

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/processor/ReviewCreationProcessorImpl.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/processor/ReviewCreationProcessorImpl.java
@@ -4,6 +4,7 @@ import org.depromeet.spot.domain.block.Block;
 import org.depromeet.spot.domain.block.BlockRow;
 import org.depromeet.spot.domain.member.Member;
 import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.domain.review.Review.ReviewType;
 import org.depromeet.spot.domain.seat.Seat;
 import org.depromeet.spot.domain.section.Section;
 import org.depromeet.spot.domain.stadium.Stadium;
@@ -54,6 +55,7 @@ public class ReviewCreationProcessorImpl implements ReviewCreationProcessor {
                 .seat(seat)
                 .dateTime(command.dateTime())
                 .content(command.content())
+                .reviewType(command.reviewType() != null ? command.reviewType() : ReviewType.VIEW)
                 .build();
     }
 


### PR DESCRIPTION
## 📌 개요 (필수)

- 등록 플로우 시야 후기, 직관 후기 분리 
- https://www.notion.so/depromeet/9df0ab254a9c4d8497c9e8b26f83de58?pvs=4
<br>

## 🔨 작업 사항 (필수)

- 직관 후기와 시야 후기는 등록, 조회 플로우가 완전히 같기 떄문에(다른 건 사진 뿐) 등록 api를 통일했어요.
- request body에 reveiwType 컬럼을 추가해서 `VIEW`면 시야후기, `FEED`면 직관 후기로 리뷰 테이블에 등록하도록 했어요.
- body에 reviewType이 들어오지 않으면 디폴트로 'VIEW'로 저장되도록 했어요.
- 리뷰 응답 필드에도 reviewType 필드를 추가했어요.

<br>

## ⚡️ 관심 리뷰 (선택)

- x

<br>

## 🌱 연관 내용 (선택)

- dev, prod에 review_type 컬럼 추가

```sql
ALTER TABLE reviews ADD COLUMN review_type VARCHAR(15) NOT NULL DEFAULT 'VIEW';
```

<br>

## 💻 실행 화면 (필수)

![image](https://github.com/user-attachments/assets/1b7b3a07-e6a0-4cba-ad0a-10187ad59194)