### PR TITLE
[BSVR-230] 블록 리뷰 조회 시야 후기 조회 + top review image 정책 업데이트

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/BlockReviewListResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/BlockReviewListResponse.java
@@ -2,7 +2,6 @@ package org.depromeet.spot.application.review.dto.response;
 
 import java.util.List;
 
-import org.depromeet.spot.domain.review.image.TopReviewImage;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.BlockKeywordInfo;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.BlockReviewListResult;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.LocationInfo;
@@ -11,7 +10,7 @@ public record BlockReviewListResponse(
         LocationInfo location,
         List<KeywordCountResponse> keywords,
         List<BaseReviewResponse> reviews,
-        List<TopReviewImageResponse> topReviewImages,
+        List<BaseReviewResponse> topReviewImages,
         Long totalElements,
         String nextCursor,
         boolean hasNext,
@@ -30,8 +29,8 @@ public record BlockReviewListResponse(
         List<KeywordCountResponse> keywordResponses =
                 result.topKeywords().stream().map(KeywordCountResponse::from).toList();
 
-        List<TopReviewImageResponse> topReviewImageResponses =
-                result.topReviewImages().stream().map(TopReviewImageResponse::from).toList();
+        List<BaseReviewResponse> topReviewImageResponses =
+                result.topReviewImages().stream().map(BaseReviewResponse::from).toList();
 
         BlockFilter filter = new BlockFilter(rowNumber, seatNumber, year, month);
 
@@ -50,19 +49,6 @@ public record BlockReviewListResponse(
 
         public static KeywordCountResponse from(BlockKeywordInfo info) {
             return new KeywordCountResponse(info.content(), info.count(), info.isPositive());
-        }
-    }
-
-    public record TopReviewImageResponse(
-            String url, Long reviewId, String blockCode, Integer rowNumber, Integer seatNumber) {
-
-        public static TopReviewImageResponse from(TopReviewImage image) {
-            return new TopReviewImageResponse(
-                    image.getUrl(),
-                    image.getReviewId(),
-                    image.getBlockCode(),
-                    image.getRowNumber(),
-                    image.getSeatNumber());
         }
     }
 

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/BlockReviewListResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/BlockReviewListResponse.java
@@ -15,7 +15,7 @@ public record BlockReviewListResponse(
         Long totalElements,
         String nextCursor,
         boolean hasNext,
-        FilterInfo filter) {
+        BlockFilter filter) {
 
     public static BlockReviewListResponse from(
             BlockReviewListResult result,
@@ -33,7 +33,7 @@ public record BlockReviewListResponse(
         List<TopReviewImageResponse> topReviewImageResponses =
                 result.topReviewImages().stream().map(TopReviewImageResponse::from).toList();
 
-        FilterInfo filter = new FilterInfo(rowNumber, seatNumber, year, month);
+        BlockFilter filter = new BlockFilter(rowNumber, seatNumber, year, month);
 
         return new BlockReviewListResponse(
                 result.location(),
@@ -66,5 +66,5 @@ public record BlockReviewListResponse(
         }
     }
 
-    public record FilterInfo(Integer rowNumber, Integer seatNumber, Integer year, Integer month) {}
+    public record BlockFilter(Integer rowNumber, Integer seatNumber, Integer year, Integer month) {}
 }

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/MyReviewListResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/MyReviewListResponse.java
@@ -3,7 +3,7 @@ package org.depromeet.spot.application.review.dto.response;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.depromeet.spot.application.review.dto.response.BlockReviewListResponse.FilterInfo;
+import org.depromeet.spot.application.review.dto.response.BlockReviewListResponse.BlockFilter;
 import org.depromeet.spot.domain.review.Review;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.MemberInfoOnMyReviewResult;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.MyReviewListResult;
@@ -13,14 +13,14 @@ public record MyReviewListResponse(
         List<MyReviewResponse> reviews,
         String nextCursor,
         boolean hasNext,
-        FilterInfo filter) {
+        BlockFilter filter) {
 
     public static MyReviewListResponse from(
             MyReviewListResult result, Integer year, Integer month) {
 
         List<MyReviewResponse> reviews =
                 result.reviews().stream().map(MyReviewResponse::from).collect(Collectors.toList());
-        FilterInfo filter = new FilterInfo(null, null, year, month);
+        BlockFilter filter = new BlockFilter(null, null, year, month);
 
         return new MyReviewListResponse(
                 result.memberInfoOnMyReviewResult(),

--- a/domain/src/main/java/org/depromeet/spot/domain/review/Review.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/review/Review.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.depromeet.spot.common.exception.review.ReviewException.InvalidReviewLikesException;
 import org.depromeet.spot.domain.block.Block;
@@ -139,5 +140,26 @@ public class Review {
 
     public void setDeletedAt(LocalDateTime now) {
         this.deletedAt = now;
+    }
+
+    public Review withLimitedImages(int limit) {
+        List<ReviewImage> limitedImages =
+                this.images.stream().limit(limit).collect(Collectors.toList());
+        return new Review(
+                this.id,
+                this.member,
+                this.stadium,
+                this.section,
+                this.block,
+                this.row,
+                this.seat,
+                this.dateTime,
+                this.content,
+                this.deletedAt,
+                limitedImages,
+                this.keywords,
+                this.likesCount,
+                this.scrapsCount,
+                this.reviewType);
     }
 }

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewCustomRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewCustomRepository.java
@@ -13,6 +13,7 @@ import static org.depromeet.spot.infrastructure.jpa.stadium.entity.QStadiumEntit
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.depromeet.spot.domain.review.Review.ReviewType;
 import org.depromeet.spot.domain.review.Review.SortCriteria;
 import org.depromeet.spot.infrastructure.jpa.review.entity.ReviewEntity;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.LocationInfo;
@@ -41,10 +42,12 @@ public class ReviewCustomRepository {
             Integer month,
             String cursor,
             SortCriteria sortBy,
-            int size) {
+            int size,
+            ReviewType reviewType) {
 
         BooleanBuilder builder =
-                buildConditions(stadiumId, blockCode, rowNumber, seatNumber, year, month);
+                buildConditions(
+                        stadiumId, blockCode, rowNumber, seatNumber, year, month, reviewType);
 
         OrderSpecifier<?>[] orderBy = getOrderBy(sortBy);
         BooleanExpression cursorCondition = getCursorCondition(sortBy, cursor);
@@ -147,7 +150,8 @@ public class ReviewCustomRepository {
             Integer year,
             Integer month) {
         BooleanBuilder builder =
-                buildConditions(stadiumId, blockCode, rowNumber, seatNumber, year, month);
+                buildConditions(
+                        stadiumId, blockCode, rowNumber, seatNumber, year, month, ReviewType.VIEW);
 
         Long count =
                 queryFactory
@@ -165,7 +169,8 @@ public class ReviewCustomRepository {
             Integer rowNumber,
             Integer seatNumber,
             Integer year,
-            Integer month) {
+            Integer month,
+            ReviewType reviewType) {
         BooleanBuilder builder = new BooleanBuilder();
 
         builder.and(reviewEntity.stadium.id.eq(stadiumId));
@@ -175,6 +180,7 @@ public class ReviewCustomRepository {
         builder.and(eqYear(year));
         builder.and(eqMonth(month));
         builder.and(reviewEntity.deletedAt.isNull());
+        builder.and(reviewEntity.reviewType.eq(reviewType));
 
         return builder;
     }

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewRepositoryImpl.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewRepositoryImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.depromeet.spot.common.exception.review.ReviewException.ReviewNotFoundException;
 import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.domain.review.Review.ReviewType;
 import org.depromeet.spot.domain.review.Review.SortCriteria;
 import org.depromeet.spot.domain.review.ReviewYearMonth;
 import org.depromeet.spot.infrastructure.jpa.review.entity.ReviewEntity;
@@ -75,7 +76,8 @@ public class ReviewRepositoryImpl implements ReviewRepository {
                         month,
                         cursor,
                         sortBy,
-                        size);
+                        size,
+                        ReviewType.VIEW);
         return reviewEntities.stream().map(ReviewEntity::toDomain).toList();
     }
 

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/image/ReviewImageCustomRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/image/ReviewImageCustomRepository.java
@@ -1,3 +1,58 @@
 package org.depromeet.spot.infrastructure.jpa.review.repository.image;
 
-public class ReviewImageCustomRepository {}
+import static org.depromeet.spot.infrastructure.jpa.block.entity.QBlockEntity.blockEntity;
+import static org.depromeet.spot.infrastructure.jpa.block.entity.QBlockRowEntity.blockRowEntity;
+import static org.depromeet.spot.infrastructure.jpa.member.entity.QLevelEntity.levelEntity;
+import static org.depromeet.spot.infrastructure.jpa.member.entity.QMemberEntity.memberEntity;
+import static org.depromeet.spot.infrastructure.jpa.review.entity.QReviewEntity.reviewEntity;
+import static org.depromeet.spot.infrastructure.jpa.seat.entity.QSeatEntity.seatEntity;
+import static org.depromeet.spot.infrastructure.jpa.section.entity.QSectionEntity.sectionEntity;
+import static org.depromeet.spot.infrastructure.jpa.stadium.entity.QStadiumEntity.stadiumEntity;
+
+import java.util.List;
+
+import org.depromeet.spot.infrastructure.jpa.review.entity.ReviewEntity;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewImageCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<ReviewEntity> findTopReviewsWithImagesByStadiumIdAndBlockCode(
+            Long stadiumId, String blockCode, int limit) {
+
+        return queryFactory
+                .selectFrom(reviewEntity)
+                .leftJoin(reviewEntity.stadium, stadiumEntity)
+                .fetchJoin()
+                .leftJoin(reviewEntity.section, sectionEntity)
+                .fetchJoin()
+                .leftJoin(reviewEntity.block, blockEntity)
+                .fetchJoin()
+                .leftJoin(reviewEntity.row, blockRowEntity)
+                .fetchJoin()
+                .leftJoin(reviewEntity.seat, seatEntity)
+                .fetchJoin()
+                .leftJoin(reviewEntity.member, memberEntity)
+                .fetchJoin()
+                .leftJoin(memberEntity.level, levelEntity)
+                .fetchJoin()
+                .where(
+                        reviewEntity
+                                .stadium
+                                .id
+                                .eq(stadiumId)
+                                .and(reviewEntity.block.code.eq(blockCode))
+                                .and(reviewEntity.images.isNotEmpty())
+                                .and(reviewEntity.deletedAt.isNull()))
+                .orderBy(reviewEntity.likesCount.desc(), reviewEntity.dateTime.desc())
+                .limit(limit)
+                .fetch();
+    }
+}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/image/ReviewImageCustomRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/image/ReviewImageCustomRepository.java
@@ -11,6 +11,7 @@ import static org.depromeet.spot.infrastructure.jpa.stadium.entity.QStadiumEntit
 
 import java.util.List;
 
+import org.depromeet.spot.domain.review.Review.ReviewType;
 import org.depromeet.spot.infrastructure.jpa.review.entity.ReviewEntity;
 import org.springframework.stereotype.Repository;
 
@@ -25,7 +26,7 @@ public class ReviewImageCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     public List<ReviewEntity> findTopReviewsWithImagesByStadiumIdAndBlockCode(
-            Long stadiumId, String blockCode, int limit) {
+            Long stadiumId, String blockCode, int limit, ReviewType reviewType) {
 
         return queryFactory
                 .selectFrom(reviewEntity)
@@ -50,7 +51,8 @@ public class ReviewImageCustomRepository {
                                 .eq(stadiumId)
                                 .and(reviewEntity.block.code.eq(blockCode))
                                 .and(reviewEntity.images.isNotEmpty())
-                                .and(reviewEntity.deletedAt.isNull()))
+                                .and(reviewEntity.deletedAt.isNull())
+                                .and(reviewEntity.reviewType.eq(reviewType)))
                 .orderBy(reviewEntity.likesCount.desc(), reviewEntity.dateTime.desc())
                 .limit(limit)
                 .fetch();

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/image/ReviewImageJpaRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/image/ReviewImageJpaRepository.java
@@ -1,28 +1,8 @@
 package org.depromeet.spot.infrastructure.jpa.review.repository.image;
 
-import java.util.List;
-
-import org.depromeet.spot.infrastructure.jpa.review.dto.TopReviewImageDto;
 import org.depromeet.spot.infrastructure.jpa.review.entity.image.ReviewImageEntity;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ReviewImageJpaRepository extends JpaRepository<ReviewImageEntity, Long> {
-    @Query(
-            "SELECT new org.depromeet.spot.infrastructure.jpa.review.dto.TopReviewImageDto(ri.url, r.id, b.code, br.number, s.seatNumber) "
-                    + "FROM ReviewImageEntity ri "
-                    + "JOIN ri.review r "
-                    + "JOIN r.block b "
-                    + "JOIN r.row br "
-                    + "JOIN r.seat s "
-                    + "WHERE b.stadiumId = :stadiumId AND b.code = :blockCode "
-                    + "ORDER BY r.createdAt DESC")
-    List<TopReviewImageDto> findTopReviewImagesByStadiumIdAndBlockCode(
-            @Param("stadiumId") Long stadiumId,
-            @Param("blockCode") String blockCode,
-            Pageable pageable);
-}
+public interface ReviewImageJpaRepository extends JpaRepository<ReviewImageEntity, Long> {}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/image/ReviewImageRepositoryImpl.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/image/ReviewImageRepositoryImpl.java
@@ -3,9 +3,9 @@ package org.depromeet.spot.infrastructure.jpa.review.repository.image;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.depromeet.spot.domain.review.image.TopReviewImage;
+import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.infrastructure.jpa.review.entity.ReviewEntity;
 import org.depromeet.spot.usecase.port.out.review.ReviewImageRepository;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
@@ -14,24 +14,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ReviewImageRepositoryImpl implements ReviewImageRepository {
 
-    private final ReviewImageJpaRepository reviewImageJpaRepository;
+    private final ReviewImageCustomRepository reviewImageCustomRepository;
 
     @Override
-    public List<TopReviewImage> findTopReviewImagesByStadiumIdAndBlockCode(
+    public List<Review> findTopReviewImagesByStadiumIdAndBlockCode(
             Long stadiumId, String blockCode, int limit) {
-        return reviewImageJpaRepository
-                .findTopReviewImagesByStadiumIdAndBlockCode(
-                        stadiumId, blockCode, PageRequest.of(0, limit))
-                .stream()
-                .map(
-                        dto ->
-                                TopReviewImage.builder()
-                                        .url(dto.url())
-                                        .reviewId(dto.reviewId())
-                                        .blockCode(dto.blockCode())
-                                        .rowNumber(dto.rowNumber())
-                                        .seatNumber(dto.seatNumber())
-                                        .build())
+        List<ReviewEntity> topReviews =
+                reviewImageCustomRepository.findTopReviewsWithImagesByStadiumIdAndBlockCode(
+                        stadiumId, blockCode, limit);
+
+        return topReviews.stream()
+                .map(ReviewEntity::toDomain)
+                .map(review -> review.withLimitedImages(1))
                 .collect(Collectors.toList());
     }
 }

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/image/ReviewImageRepositoryImpl.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/image/ReviewImageRepositoryImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.domain.review.Review.ReviewType;
 import org.depromeet.spot.infrastructure.jpa.review.entity.ReviewEntity;
 import org.depromeet.spot.usecase.port.out.review.ReviewImageRepository;
 import org.springframework.stereotype.Repository;
@@ -21,7 +22,7 @@ public class ReviewImageRepositoryImpl implements ReviewImageRepository {
             Long stadiumId, String blockCode, int limit) {
         List<ReviewEntity> topReviews =
                 reviewImageCustomRepository.findTopReviewsWithImagesByStadiumIdAndBlockCode(
-                        stadiumId, blockCode, limit);
+                        stadiumId, blockCode, limit, ReviewType.VIEW);
 
         return topReviews.stream()
                 .map(ReviewEntity::toDomain)

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
@@ -6,7 +6,6 @@ import org.depromeet.spot.domain.member.Member;
 import org.depromeet.spot.domain.review.Review;
 import org.depromeet.spot.domain.review.Review.SortCriteria;
 import org.depromeet.spot.domain.review.ReviewYearMonth;
-import org.depromeet.spot.domain.review.image.TopReviewImage;
 
 import lombok.Builder;
 
@@ -48,7 +47,7 @@ public interface ReadReviewUsecase {
             LocationInfo location,
             List<Review> reviews,
             List<BlockKeywordInfo> topKeywords,
-            List<TopReviewImage> topReviewImages,
+            List<Review> topReviewImages,
             Long totalElements,
             String nextCursor,
             boolean hasNext) {}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewImageRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewImageRepository.java
@@ -2,10 +2,10 @@ package org.depromeet.spot.usecase.port.out.review;
 
 import java.util.List;
 
-import org.depromeet.spot.domain.review.image.TopReviewImage;
+import org.depromeet.spot.domain.review.Review;
 
 public interface ReviewImageRepository {
 
-    List<TopReviewImage> findTopReviewImagesByStadiumIdAndBlockCode(
+    List<Review> findTopReviewImagesByStadiumIdAndBlockCode(
             Long stadiumId, String blockCode, int limit);
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -8,7 +8,6 @@ import org.depromeet.spot.domain.member.Member;
 import org.depromeet.spot.domain.review.Review;
 import org.depromeet.spot.domain.review.Review.SortCriteria;
 import org.depromeet.spot.domain.review.ReviewYearMonth;
-import org.depromeet.spot.domain.review.image.TopReviewImage;
 import org.depromeet.spot.domain.review.keyword.Keyword;
 import org.depromeet.spot.domain.review.keyword.ReviewKeyword;
 import org.depromeet.spot.domain.team.BaseballTeam;
@@ -80,9 +79,11 @@ public class ReadReviewService implements ReadReviewUsecase {
                         stadiumId, blockCode, TOP_KEYWORDS_LIMIT);
 
         // stadiumId랑 blockCode로 blockId를 조회 후 이걸 통해 topImages를 조회
-        List<TopReviewImage> topReviewImages =
+        List<Review> topReviewImages =
                 reviewImageRepository.findTopReviewImagesByStadiumIdAndBlockCode(
                         stadiumId, blockCode, TOP_IMAGES_LIMIT);
+
+        List<Review> topReviewImagesWithKeywords = mapKeywordsToReviews(topReviewImages);
 
         List<Review> reviewsWithKeywords = mapKeywordsToReviews(reviews);
 
@@ -94,7 +95,7 @@ public class ReadReviewService implements ReadReviewUsecase {
                 .location(locationInfo)
                 .reviews(reviewsWithKeywords)
                 .topKeywords(topKeywords)
-                .topReviewImages(topReviewImages)
+                .topReviewImages(topReviewImagesWithKeywords)
                 .totalElements(totalElements)
                 .nextCursor(nextCursor)
                 .hasNext(hasNext)


### PR DESCRIPTION
## 📌 개요 (필수)

- 블록 리뷰 조회 시야 후기 조회 
- top review image 정책 업데이트
- [2차 MVP 블록별 리뷰 조회 API 슬랙 논의](https://depromeet-15th.slack.com/archives/C075Z9K5QH4/p1724330990864519)
<br>

## 🔨 작업 사항 (필수)

- 블록 리뷰 조회할 때 likesCount랑 scrapsCount 컬럼 포함하도록 업데이트
- 블록 리뷰 조회할 때 시야후기만 조회하도록 업데이트(직관후기는 비공개)
- top review images에 리뷰 전체 정보를 포함할 수 있도록 업데이트
- top review images 정책 변경 반영: 최신순 -> 공감순 - 최신순

<br>

## ⚡️ 관심 리뷰 (선택)

- x

<br>

## 🌱 연관 내용 (선택)

- x

<br>

## 💻 실행 화면 (필수)

![image](https://github.com/user-attachments/assets/50c6c925-a602-488e-94c9-3fa08804daf2)
