### PR TITLE
[BSVR-239] 로컬/테스트에서 redis를 사용하기 위한 세팅

### DIFF
--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ server:
 spring:
     # 서브모듈 profile
     profiles:
-        active: dev
+        active: local
         group:
             local:
                 - jpa

--- a/infrastructure/build.gradle.kts
+++ b/infrastructure/build.gradle.kts
@@ -27,6 +27,10 @@ dependencies {
     // redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis:_")
     implementation("org.redisson:redisson-spring-boot-starter:_")
+    implementation("it.ozimov:embedded-redis:_") {
+        exclude(group = "org.slf4j", module = "slf4j-simple")
+        because("테스트 환경에서 사용할 embedded-redis")
+    }
 
     // webflux (HTTP 요청에 사용)
     implementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/redis/EmbeddedRedisConfig.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/redis/EmbeddedRedisConfig.java
@@ -1,3 +1,75 @@
 package org.depromeet.spot.infrastructure.redis;
 
-public class EmbeddedRedisConfig {}
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import redis.embedded.RedisServer;
+
+@Slf4j
+@Configuration
+@Profile("local | test")
+@RequiredArgsConstructor
+public class EmbeddedRedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void redisServer() throws IOException {
+        int port = isRedisPortUsed() ? findAvailablePort() : redisProperties.port();
+        log.info("embedded redis port = {}", port);
+        redisServer = new RedisServer(port);
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+
+    private boolean isRedisPortUsed() throws IOException {
+        Process process = getProcessListeningOnPort(redisProperties.port());
+        return isRunningProcess(process);
+    }
+
+    private Process getProcessListeningOnPort(final int port) throws IOException {
+        String command = "lsof -i :" + port + " | grep LISTEN";
+        String[] shell = {"/bin/sh", "-c", command};
+        return Runtime.getRuntime().exec(shell);
+    }
+
+    private boolean isRunningProcess(Process process) {
+        try (BufferedReader input =
+                new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line = input.readLine();
+            if (line == null) {
+                return false;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return true;
+    }
+
+    private int findAvailablePort() throws IOException {
+        for (int port = 10000; port <= 65535; port++) {
+            Process process = getProcessListeningOnPort(port);
+            if (!isRunningProcess(process)) {
+                return port;
+            }
+        }
+        throw new IllegalArgumentException("10000 ~ 65535 사이에서 사용 가능한 포트가 없습니다.");
+    }
+}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/redis/EmbeddedRedisConfig.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/redis/EmbeddedRedisConfig.java
@@ -1,0 +1,3 @@
+package org.depromeet.spot.infrastructure.redis;
+
+public class EmbeddedRedisConfig {}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/redis/RedissonConfig.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/redis/RedissonConfig.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 
 @Configuration
 @RequiredArgsConstructor
-public class RedisConfig {
+public class RedissonConfig {
 
     private static final String REDISSON_HOST_PREFIX = "redis://";
     private final RedisProperties redisProperties;

--- a/versions.properties
+++ b/versions.properties
@@ -58,3 +58,5 @@ version.com.github.loki4j..loki-logback-appender=1.4.2
 version.io.micrometer..micrometer-registry-prometheus=1.12.4
 
 version.com.github.ben-manes.caffeine..caffeine=3.1.8
+
+version.it.ozimov..embedded-redis=0.7.3


### PR DESCRIPTION
## 📌 개요 (필수)

- 현재 aws ElastiCache (redis)를 사용 중이에요.
- 그런데 로컬이나 테스트 profile에서 dev / prod redis를 사용하면 데이터가 꼬일 수 있어요.
  - 캐시 목적으로 사용하면 캐시 데이터가 겹칠 수 있고
  - 분산락 목적으로 사용하면 락 획득을 위한 대기 시간이 길어질 수도 있고... 
- redis를 로컬에서 직접 설치해서 사용해도 되지만, 최대한 프로젝트를 clone받고 바로 실행해볼 수 있는 상황으로 만들고 싶었어요.
- 따라서 local & test profile에서는 [embedded redis opensource](https://github.com/ozimov/embedded-redis)를 활용하도록 설정해요.

<br>

## 🔨 작업 사항 (필수)

- embedded redis 설정 추가

<br>

## ✅ 연관 사항 (선택)

- 각자 local에서 pull 받고 잘 동작하는지 한 번씩 체크해주세요~

<br>

## 💻 실행 화면 (필수)

- 이미 레디스 포트(6379)를 사용 중이라 다른 포트를 배정한 경우
<img width="483" alt="스크린샷 2024-08-25 오후 4 20 39" src="https://github.com/user-attachments/assets/7289fdb3-9b6d-414d-9eda-033420fbf1a0">