### PR TITLE
[BSVR-242] 스크랩 조회 get요청에 request body쓴 이슈  + scrapsCount 조회 안되는 이슈 픽스

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/review/scrap/ReviewScrapController.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/scrap/ReviewScrapController.java
@@ -12,10 +12,8 @@ import org.depromeet.spot.usecase.port.in.review.scrap.ReviewScrapUsecase;
 import org.depromeet.spot.usecase.port.in.review.scrap.ReviewScrapUsecase.MyScrapListResult;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -51,8 +49,8 @@ public class ReviewScrapController {
             description = "stadiumId,  months, good, bad로 필터링 가능하다.")
     public MyScrapListResponse findMyReviews(
             @Parameter(hidden = true) Long memberId,
-            @RequestBody @Valid MyScrapRequest request,
-            @ModelAttribute @Valid PageRequest pageRequest) {
+            @Valid MyScrapRequest request,
+            @Valid PageRequest pageRequest) {
 
         MyScrapListResult result =
                 reviewScrapUsecase.findMyScrappedReviews(

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -244,6 +244,7 @@ public class ReadReviewService implements ReadReviewUsecase {
                         .images(review.getImages())
                         .keywords(mappedKeywords)
                         .likesCount(review.getLikesCount())
+                        .scrapsCount(review.getScrapsCount())
                         .build();
 
         mappedReview.setKeywordMap(keywordMap);

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -20,6 +20,7 @@ import org.depromeet.spot.usecase.port.out.review.ReviewLikeRepository;
 import org.depromeet.spot.usecase.port.out.review.ReviewRepository;
 import org.depromeet.spot.usecase.port.out.review.ReviewScrapRepository;
 import org.depromeet.spot.usecase.port.out.team.BaseballTeamRepository;
+import org.depromeet.spot.usecase.service.review.processor.ReadReviewProcessor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,6 +39,7 @@ public class ReadReviewService implements ReadReviewUsecase {
     private final BaseballTeamRepository baseballTeamRepository;
     private final ReviewLikeRepository reviewLikeRepository;
     private final ReviewScrapRepository reviewScrapRepository;
+    private final ReadReviewProcessor readReviewProcessor;
 
     private static final int TOP_KEYWORDS_LIMIT = 5;
     private static final int TOP_IMAGES_LIMIT = 5;
@@ -93,7 +95,7 @@ public class ReadReviewService implements ReadReviewUsecase {
         List<Review> reviewsWithKeywords = mapKeywordsToReviews(reviews);
 
         // 유저의 리뷰 좋아요, 스크랩 여부
-        setLikedAndScrappedStatus(reviewsWithKeywords, memberId);
+        readReviewProcessor.setLikedAndScrappedStatus(reviewsWithKeywords, memberId);
 
         long totalElements =
                 reviewRepository.countByStadiumIdAndBlockCode(

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -289,6 +289,7 @@ public class ReadReviewService implements ReadReviewUsecase {
                         .images(review.getImages())
                         .keywords(mappedKeywords) // 리뷰 키워드 담당
                         .likesCount(review.getLikesCount())
+                        .scrapsCount(review.getScrapsCount())
                         .build();
 
         // Keyword 정보를 Review 객체에 추가

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/processor/ReadReviewProcessor.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/processor/ReadReviewProcessor.java
@@ -1,0 +1,10 @@
+package org.depromeet.spot.usecase.service.review.processor;
+
+import java.util.List;
+
+import org.depromeet.spot.domain.review.Review;
+
+public interface ReadReviewProcessor {
+
+    void setLikedAndScrappedStatus(List<Review> reviews, Long memberId);
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/processor/ReadReviewProcessorImpl.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/processor/ReadReviewProcessorImpl.java
@@ -1,0 +1,36 @@
+package org.depromeet.spot.usecase.service.review.processor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.usecase.port.out.review.ReviewLikeRepository;
+import org.depromeet.spot.usecase.port.out.review.ReviewScrapRepository;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ReadReviewProcessorImpl implements ReadReviewProcessor {
+
+    private final ReviewLikeRepository reviewLikeRepository;
+    private final ReviewScrapRepository reviewScrapRepository;
+
+    public void setLikedAndScrappedStatus(List<Review> reviews, Long memberId) {
+        List<Long> reviewIds = reviews.stream().map(Review::getId).collect(Collectors.toList());
+
+        Map<Long, Boolean> likedMap =
+                reviewLikeRepository.existsByMemberIdAndReviewIds(memberId, reviewIds);
+        Map<Long, Boolean> scrappedMap =
+                reviewScrapRepository.existsByMemberIdAndReviewIds(memberId, reviewIds);
+
+        reviews.forEach(
+                review -> {
+                    boolean isLiked = likedMap.getOrDefault(review.getId(), false);
+                    boolean isScrapped = scrappedMap.getOrDefault(review.getId(), false);
+                    review.setLikedAndScrapped(isLiked, isScrapped);
+                });
+    }
+}

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/scrap/ReviewScrapService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/scrap/ReviewScrapService.java
@@ -10,6 +10,7 @@ import org.depromeet.spot.usecase.port.in.review.page.PageCommand;
 import org.depromeet.spot.usecase.port.in.review.scrap.ReviewScrapUsecase;
 import org.depromeet.spot.usecase.port.out.review.ReviewScrapRepository;
 import org.depromeet.spot.usecase.service.review.ReadReviewService;
+import org.depromeet.spot.usecase.service.review.processor.ReadReviewProcessor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +25,7 @@ public class ReviewScrapService implements ReviewScrapUsecase {
     private final UpdateReviewUsecase updateReviewUsecase;
     private final ReviewScrapRepository scrapRepository;
     private final ReadReviewService readReviewService;
+    private final ReadReviewProcessor readReviewProcessor;
 
     @Override
     public MyScrapListResult findMyScrappedReviews(
@@ -52,6 +54,9 @@ public class ReviewScrapService implements ReviewScrapUsecase {
                         : null;
 
         List<Review> reviewsWithKeywords = readReviewService.mapKeywordsToReviews(reviews);
+
+        // 유저의 리뷰 좋아요, 스크랩 여부
+        readReviewProcessor.setLikedAndScrappedStatus(reviewsWithKeywords, memberId);
 
         Long totalScrapCount =
                 scrapRepository.getTotalCount(

--- a/usecase/src/test/java/org/depromeet/spot/usecase/service/review/ReviewScrapServiceTest.java
+++ b/usecase/src/test/java/org/depromeet/spot/usecase/service/review/ReviewScrapServiceTest.java
@@ -19,6 +19,7 @@ import org.depromeet.spot.usecase.port.in.review.page.PageCommand;
 import org.depromeet.spot.usecase.port.in.review.scrap.ReviewScrapUsecase.MyScrapCommand;
 import org.depromeet.spot.usecase.port.in.review.scrap.ReviewScrapUsecase.MyScrapListResult;
 import org.depromeet.spot.usecase.service.fake.FakeReviewScrapRepository;
+import org.depromeet.spot.usecase.service.review.processor.ReadReviewProcessor;
 import org.depromeet.spot.usecase.service.review.scrap.ReviewScrapService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,7 @@ class ReviewScrapServiceTest {
     @Mock private ReadReviewUsecase readReviewUsecase;
     @Mock private UpdateReviewUsecase updateReviewUsecase;
     @Mock private ReadReviewService readReviewService;
+    @Mock private ReadReviewProcessor readReviewProcessor;
 
     @BeforeEach
     void init() {
@@ -43,7 +45,8 @@ class ReviewScrapServiceTest {
                         readReviewUsecase,
                         updateReviewUsecase,
                         fakeReviewScrapRepository,
-                        readReviewService);
+                        readReviewService,
+                        readReviewProcessor);
     }
 
     @Test


### PR DESCRIPTION
## 📌 개요 (필수)

- 스크랩 조회 get요청에 request body쓴 이슈  + scrapsCount 조회 안되는 이슈 픽스

<br>

## 🔨 작업 사항 (필수)

- [스크랩 조회 시 get요청에 request body를 사용한 것을 param으로 수정](https://github.com/depromeet/SPOT-server/commit/59b556e4738e92c06cf67030471377e1b08fdded)
- [keyword 매핑부분에서 scrapsCount 빌더에 추가](https://github.com/depromeet/SPOT-server/commit/b69911ae0d872eba54907e6f58abae32458ab774)
- [스크랩 조회 시 isScrapped, isLiked 업데이트 로직 추가](https://github.com/depromeet/SPOT-server/commit/04917d08760aec08323357a284f23fc5b8e0c19f)
- 스크랩 조회 시 사용자의 스크랩, 좋아요 여부 업데이트 추가

<br>

## ⚡️ 관심 리뷰 (선택)

- x

<br>

## 🌱 연관 내용 (선택)

- x

<br>

## 💻 실행 화면 (필수)

![image](https://github.com/user-attachments/assets/34815c7c-cf41-447e-acda-16283bf3e5dd)