### PR TITLE
[BSVR-234] 시야 아카이빙 시야 후기/직관 후기 분리

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/review/ReadReviewController.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/ReadReviewController.java
@@ -14,6 +14,7 @@ import org.depromeet.spot.application.review.dto.response.BlockReviewListRespons
 import org.depromeet.spot.application.review.dto.response.MyRecentReviewResponse;
 import org.depromeet.spot.application.review.dto.response.MyReviewListResponse;
 import org.depromeet.spot.application.review.dto.response.ReviewMonthsResponse;
+import org.depromeet.spot.domain.review.Review.ReviewType;
 import org.depromeet.spot.domain.review.ReviewYearMonth;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.BlockReviewListResult;
@@ -69,11 +70,23 @@ public class ReadReviewController {
 
     @CurrentMember
     @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/reviews/recentReview")
+    @Operation(summary = "자신이 작성한 가장 최근 리뷰 1개를 조회한다.")
+    public MyRecentReviewResponse findMyRecentReview(@Parameter(hidden = true) Long memberId) {
+
+        MyRecentReviewResult result = readReviewUsecase.findLastReviewByMemberId(memberId);
+        return MyRecentReviewResponse.from(result);
+    }
+
+    @CurrentMember
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping("/reviews/months")
     @Operation(summary = "리뷰가 작성된 년도와 월 정보를 조회한다.")
-    public ReviewMonthsResponse findReviewMonths(@Parameter(hidden = true) Long memberId) {
+    public ReviewMonthsResponse findReviewMonths(
+            @Parameter(hidden = true) Long memberId,
+            @Parameter(description = "리뷰 타입: VIEW/FEED") ReviewType reviewType) {
 
-        List<ReviewYearMonth> yearMonths = readReviewUsecase.findReviewMonths(memberId);
+        List<ReviewYearMonth> yearMonths = readReviewUsecase.findReviewMonths(memberId, reviewType);
         return ReviewMonthsResponse.from(yearMonths);
     }
 
@@ -94,18 +107,9 @@ public class ReadReviewController {
                         request.month(),
                         request.cursor(),
                         request.sortBy(),
-                        request.size());
+                        request.size(),
+                        request.reviewType());
         return MyReviewListResponse.from(result, request.year(), request.month());
-    }
-
-    @CurrentMember
-    @ResponseStatus(HttpStatus.OK)
-    @GetMapping("/reviews/recentReview")
-    @Operation(summary = "자신이 작성한 가장 최근 리뷰 1개를 조회한다.")
-    public MyRecentReviewResponse findMyRecentReview(@Parameter(hidden = true) Long memberId) {
-
-        MyRecentReviewResult result = readReviewUsecase.findLastReviewByMemberId(memberId);
-        return MyRecentReviewResponse.from(result);
     }
 
     @CurrentMember

--- a/application/src/main/java/org/depromeet/spot/application/review/ReadReviewController.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/ReadReviewController.java
@@ -11,6 +11,7 @@ import org.depromeet.spot.application.review.dto.request.BlockReviewRequest;
 import org.depromeet.spot.application.review.dto.request.MyReviewRequest;
 import org.depromeet.spot.application.review.dto.response.BaseReviewResponse;
 import org.depromeet.spot.application.review.dto.response.BlockReviewListResponse;
+import org.depromeet.spot.application.review.dto.response.MemberInfoOnMyReviewResponse;
 import org.depromeet.spot.application.review.dto.response.MyRecentReviewResponse;
 import org.depromeet.spot.application.review.dto.response.MyReviewListResponse;
 import org.depromeet.spot.application.review.dto.response.ReviewMonthsResponse;
@@ -88,6 +89,16 @@ public class ReadReviewController {
 
         List<ReviewYearMonth> yearMonths = readReviewUsecase.findReviewMonths(memberId, reviewType);
         return ReviewMonthsResponse.from(yearMonths);
+    }
+
+    @CurrentMember
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/reviews/userInfo")
+    @Operation(summary = "사용자의 리뷰 관련 정보를 조회한다.")
+    public MemberInfoOnMyReviewResponse findMemberInfoOnMyReview(
+            @Parameter(hidden = true) Long memberId) {
+        return MemberInfoOnMyReviewResponse.from(
+                readReviewUsecase.findMemberInfoOnMyReview(memberId));
     }
 
     @CurrentMember

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/request/MyReviewRequest.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/request/MyReviewRequest.java
@@ -3,6 +3,7 @@ package org.depromeet.spot.application.review.dto.request;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
+import org.depromeet.spot.domain.review.Review.ReviewType;
 import org.depromeet.spot.domain.review.Review.SortCriteria;
 
 import io.swagger.v3.oas.annotations.Parameter;
@@ -12,4 +13,5 @@ public record MyReviewRequest(
         @Min(1) @Max(12) @Parameter(description = "월 (1-12)") Integer month,
         @Parameter(description = "다음 페이지 커서") String cursor,
         @Parameter(description = "정렬 기준", example = "DATE_TIME") SortCriteria sortBy,
-        @Parameter(description = "페이지 크기") Integer size) {}
+        @Parameter(description = "페이지 크기") Integer size,
+        @Parameter(description = "리뷰 타입: VIEW/FEED") ReviewType reviewType) {}

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/MemberInfoOnMyReviewResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/MemberInfoOnMyReviewResponse.java
@@ -1,0 +1,31 @@
+package org.depromeet.spot.application.review.dto.response;
+
+import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.MemberInfoOnMyReviewResult;
+
+import lombok.Builder;
+
+@Builder
+public record MemberInfoOnMyReviewResponse(
+        Long userId,
+        String profileImageUrl,
+        Integer level,
+        String levelTitle,
+        String nickname,
+        Long reviewCount,
+        Long totalLikes,
+        Long teamId,
+        String teamName) {
+    public static MemberInfoOnMyReviewResponse from(MemberInfoOnMyReviewResult result) {
+        return MemberInfoOnMyReviewResponse.builder()
+                .userId(result.userId())
+                .profileImageUrl(result.profileImageUrl())
+                .level(result.level())
+                .levelTitle(result.levelTitle())
+                .nickname(result.nickname())
+                .reviewCount(result.reviewCount())
+                .totalLikes(result.totalLikes())
+                .teamId(result.teamId())
+                .teamName(result.teamName())
+                .build();
+    }
+}

--- a/application/src/main/java/org/depromeet/spot/application/review/dto/response/MyReviewListResponse.java
+++ b/application/src/main/java/org/depromeet/spot/application/review/dto/response/MyReviewListResponse.java
@@ -5,15 +5,10 @@ import java.util.stream.Collectors;
 
 import org.depromeet.spot.application.review.dto.response.BlockReviewListResponse.BlockFilter;
 import org.depromeet.spot.domain.review.Review;
-import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.MemberInfoOnMyReviewResult;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.MyReviewListResult;
 
 public record MyReviewListResponse(
-        MemberInfoOnMyReviewResult memberInfoOnMyReview,
-        List<MyReviewResponse> reviews,
-        String nextCursor,
-        boolean hasNext,
-        BlockFilter filter) {
+        List<MyReviewResponse> reviews, String nextCursor, boolean hasNext, BlockFilter filter) {
 
     public static MyReviewListResponse from(
             MyReviewListResult result, Integer year, Integer month) {
@@ -22,12 +17,7 @@ public record MyReviewListResponse(
                 result.reviews().stream().map(MyReviewResponse::from).collect(Collectors.toList());
         BlockFilter filter = new BlockFilter(null, null, year, month);
 
-        return new MyReviewListResponse(
-                result.memberInfoOnMyReviewResult(),
-                reviews,
-                result.nextCursor(),
-                result.hasNext(),
-                filter);
+        return new MyReviewListResponse(reviews, result.nextCursor(), result.hasNext(), filter);
     }
 
     public record MyReviewResponse(

--- a/domain/src/main/java/org/depromeet/spot/domain/review/ReviewCount.java
+++ b/domain/src/main/java/org/depromeet/spot/domain/review/ReviewCount.java
@@ -1,0 +1,3 @@
+package org.depromeet.spot.domain.review;
+
+public record ReviewCount(long reviewCount, long totalLikes) {}

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewCustomRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewCustomRepository.java
@@ -86,13 +86,15 @@ public class ReviewCustomRepository {
             Integer month,
             String cursor,
             SortCriteria sortBy,
-            int size) {
+            int size,
+            ReviewType reviewType) {
 
         BooleanBuilder builder = new BooleanBuilder();
         builder.and(reviewEntity.member.id.eq(userId));
         builder.and(eqYear(year));
         builder.and(eqMonth(month));
         builder.and(reviewEntity.deletedAt.isNull());
+        builder.and(reviewEntity.reviewType.eq(reviewType));
 
         OrderSpecifier<?>[] orderBy = getOrderBy(sortBy);
         BooleanExpression cursorCondition = getCursorCondition(sortBy, cursor);

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewJpaRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewJpaRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.depromeet.spot.domain.review.Review.ReviewType;
+import org.depromeet.spot.domain.review.ReviewCount;
 import org.depromeet.spot.domain.review.ReviewYearMonth;
 import org.depromeet.spot.infrastructure.jpa.review.entity.ReviewEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,6 +24,14 @@ public interface ReviewJpaRepository extends JpaRepository<ReviewEntity, Long> {
                     + "ORDER BY YEAR(r.dateTime) DESC, MONTH(r.dateTime) DESC")
     List<ReviewYearMonth> findReviewMonthsByMemberId(
             @Param("memberId") Long memberId, @Param("reviewType") ReviewType reviewType);
+
+    @Query(
+            "SELECT new org.depromeet.spot.domain.review.ReviewCount("
+                    + "COUNT(r), "
+                    + "COALESCE(SUM(CASE WHEN r.reviewType = org.depromeet.spot.domain.review.Review.ReviewType.VIEW THEN r.likesCount ELSE 0 END), 0)) "
+                    + "FROM ReviewEntity r "
+                    + "WHERE r.member.id = :memberId AND r.deletedAt IS NULL")
+    ReviewCount countAndSumLikesByMemberId(@Param("memberId") Long memberId);
 
     @Modifying
     @Query(

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewJpaRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewJpaRepository.java
@@ -28,10 +28,11 @@ public interface ReviewJpaRepository extends JpaRepository<ReviewEntity, Long> {
     @Query(
             "SELECT new org.depromeet.spot.domain.review.ReviewCount("
                     + "COUNT(r), "
-                    + "COALESCE(SUM(CASE WHEN r.reviewType = org.depromeet.spot.domain.review.Review.ReviewType.VIEW THEN r.likesCount ELSE 0 END), 0)) "
+                    + "COALESCE(SUM(CASE WHEN r.reviewType = :viewType THEN r.likesCount ELSE 0 END), 0)) "
                     + "FROM ReviewEntity r "
                     + "WHERE r.member.id = :memberId AND r.deletedAt IS NULL")
-    ReviewCount countAndSumLikesByMemberId(@Param("memberId") Long memberId);
+    ReviewCount countAndSumLikesByMemberId(
+            @Param("memberId") Long memberId, @Param("viewType") ReviewType viewType);
 
     @Modifying
     @Query(

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewJpaRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewJpaRepository.java
@@ -3,6 +3,7 @@ package org.depromeet.spot.infrastructure.jpa.review.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.depromeet.spot.domain.review.Review.ReviewType;
 import org.depromeet.spot.domain.review.ReviewYearMonth;
 import org.depromeet.spot.infrastructure.jpa.review.entity.ReviewEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,9 +18,11 @@ public interface ReviewJpaRepository extends JpaRepository<ReviewEntity, Long> {
             "SELECT new org.depromeet.spot.domain.review.ReviewYearMonth(YEAR(r.dateTime), MONTH(r.dateTime)) "
                     + "FROM ReviewEntity r WHERE r.member.id = :memberId "
                     + "AND r.deletedAt IS NULL "
+                    + "AND r.reviewType = :reviewType "
                     + "GROUP BY YEAR(r.dateTime), MONTH(r.dateTime) "
                     + "ORDER BY YEAR(r.dateTime) DESC, MONTH(r.dateTime) DESC")
-    List<ReviewYearMonth> findReviewMonthsByMemberId(@Param("memberId") Long memberId);
+    List<ReviewYearMonth> findReviewMonthsByMemberId(
+            @Param("memberId") Long memberId, @Param("reviewType") ReviewType reviewType);
 
     @Modifying
     @Query(

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewRepositoryImpl.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewRepositoryImpl.java
@@ -7,6 +7,7 @@ import org.depromeet.spot.common.exception.review.ReviewException.ReviewNotFound
 import org.depromeet.spot.domain.review.Review;
 import org.depromeet.spot.domain.review.Review.ReviewType;
 import org.depromeet.spot.domain.review.Review.SortCriteria;
+import org.depromeet.spot.domain.review.ReviewCount;
 import org.depromeet.spot.domain.review.ReviewYearMonth;
 import org.depromeet.spot.infrastructure.jpa.review.entity.ReviewEntity;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.LocationInfo;
@@ -53,6 +54,11 @@ public class ReviewRepositoryImpl implements ReviewRepository {
     @Override
     public long countByUserId(Long id) {
         return reviewJpaRepository.countByMemberIdAndDeletedAtIsNull(id);
+    }
+
+    @Override
+    public ReviewCount countAndSumLikesByUserId(Long id) {
+        return reviewJpaRepository.countAndSumLikesByMemberId(id);
     }
 
     @Override

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewRepositoryImpl.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewRepositoryImpl.java
@@ -58,7 +58,7 @@ public class ReviewRepositoryImpl implements ReviewRepository {
 
     @Override
     public ReviewCount countAndSumLikesByUserId(Long id) {
-        return reviewJpaRepository.countAndSumLikesByMemberId(id);
+        return reviewJpaRepository.countAndSumLikesByMemberId(id, ReviewType.VIEW);
     }
 
     @Override

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewRepositoryImpl.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewRepositoryImpl.java
@@ -88,15 +88,17 @@ public class ReviewRepositoryImpl implements ReviewRepository {
             Integer month,
             String cursor,
             SortCriteria sortBy,
-            Integer size) {
+            Integer size,
+            ReviewType reviewType) {
         List<ReviewEntity> reviewEntities =
-                reviewCustomRepository.findAllByUserId(userId, year, month, cursor, sortBy, size);
+                reviewCustomRepository.findAllByUserId(
+                        userId, year, month, cursor, sortBy, size, reviewType);
         return reviewEntities.stream().map(ReviewEntity::toDomain).toList();
     }
 
     @Override
-    public List<ReviewYearMonth> findReviewMonthsByMemberId(Long memberId) {
-        return reviewJpaRepository.findReviewMonthsByMemberId(memberId);
+    public List<ReviewYearMonth> findReviewMonthsByMemberId(Long memberId, ReviewType reviewType) {
+        return reviewJpaRepository.findReviewMonthsByMemberId(memberId, reviewType);
     }
 
     @Override

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
@@ -34,6 +34,8 @@ public interface ReadReviewUsecase {
             Integer size,
             ReviewType reviewType);
 
+    MemberInfoOnMyReviewResult findMemberInfoOnMyReview(Long memberId);
+
     List<ReviewYearMonth> findReviewMonths(Long memberId, ReviewType reviewType);
 
     MyRecentReviewResult findLastReviewByMemberId(Long memberId);

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.depromeet.spot.domain.member.Member;
 import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.domain.review.Review.ReviewType;
 import org.depromeet.spot.domain.review.Review.SortCriteria;
 import org.depromeet.spot.domain.review.ReviewYearMonth;
 
@@ -29,9 +30,10 @@ public interface ReadReviewUsecase {
             Integer month,
             String cursor,
             SortCriteria sortBy,
-            Integer size);
+            Integer size,
+            ReviewType reviewType);
 
-    List<ReviewYearMonth> findReviewMonths(Long memberId);
+    List<ReviewYearMonth> findReviewMonths(Long memberId, ReviewType reviewType);
 
     MyRecentReviewResult findLastReviewByMemberId(Long memberId);
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/ReadReviewUsecase.java
@@ -6,6 +6,7 @@ import org.depromeet.spot.domain.member.Member;
 import org.depromeet.spot.domain.review.Review;
 import org.depromeet.spot.domain.review.Review.ReviewType;
 import org.depromeet.spot.domain.review.Review.SortCriteria;
+import org.depromeet.spot.domain.review.ReviewCount;
 import org.depromeet.spot.domain.review.ReviewYearMonth;
 
 import lombok.Builder;
@@ -76,30 +77,33 @@ public interface ReadReviewUsecase {
             String levelTitle,
             String nickname,
             Long reviewCount,
+            Long totalLikes,
             Long teamId,
             String teamName) {
-        public static MemberInfoOnMyReviewResult of(Member member, long totalReviewCount) {
+        public static MemberInfoOnMyReviewResult of(Member member, ReviewCount reviewCount) {
             return MemberInfoOnMyReviewResult.builder()
                     .userId(member.getId())
                     .profileImageUrl(member.getProfileImage())
                     .level(member.getLevel().getValue())
                     .levelTitle(member.getLevel().getTitle())
                     .nickname(member.getNickname())
-                    .reviewCount(totalReviewCount)
+                    .reviewCount(reviewCount.reviewCount())
+                    .totalLikes(reviewCount.totalLikes())
                     .teamId(null)
                     .teamName(null)
                     .build();
         }
 
         public static MemberInfoOnMyReviewResult of(
-                Member member, long totalReviewCount, String teamName) {
+                Member member, ReviewCount reviewCount, String teamName) {
             return MemberInfoOnMyReviewResult.builder()
                     .userId(member.getId())
                     .profileImageUrl(member.getProfileImage())
                     .level(member.getLevel().getValue())
                     .levelTitle(member.getLevel().getTitle())
                     .nickname(member.getNickname())
-                    .reviewCount(totalReviewCount)
+                    .reviewCount(reviewCount.reviewCount())
+                    .totalLikes(reviewCount.totalLikes())
                     .teamId(member.getTeamId())
                     .teamName(teamName)
                     .build();

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewRepository.java
@@ -3,6 +3,7 @@ package org.depromeet.spot.usecase.port.out.review;
 import java.util.List;
 
 import org.depromeet.spot.domain.review.Review;
+import org.depromeet.spot.domain.review.Review.ReviewType;
 import org.depromeet.spot.domain.review.Review.SortCriteria;
 import org.depromeet.spot.domain.review.ReviewYearMonth;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.LocationInfo;
@@ -35,9 +36,10 @@ public interface ReviewRepository {
             Integer month,
             String cursor,
             SortCriteria sortBy,
-            Integer size);
+            Integer size,
+            ReviewType reviewType);
 
-    List<ReviewYearMonth> findReviewMonthsByMemberId(Long memberId);
+    List<ReviewYearMonth> findReviewMonthsByMemberId(Long memberId, ReviewType reviewType);
 
     Long softDeleteByIdAndMemberId(Long reviewId, Long memberId);
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.depromeet.spot.domain.review.Review;
 import org.depromeet.spot.domain.review.Review.ReviewType;
 import org.depromeet.spot.domain.review.Review.SortCriteria;
+import org.depromeet.spot.domain.review.ReviewCount;
 import org.depromeet.spot.domain.review.ReviewYearMonth;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase.LocationInfo;
 
@@ -18,6 +19,8 @@ public interface ReviewRepository {
     Review findById(Long id);
 
     long countByUserId(Long userId);
+
+    ReviewCount countAndSumLikesByUserId(Long id);
 
     List<Review> findByStadiumIdAndBlockCode(
             Long stadiumId,

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -150,7 +150,8 @@ public class ReadReviewService implements ReadReviewUsecase {
         MemberInfoOnMyReviewResult memberInfo;
         if (member.getTeamId() == null) {
             memberInfo =
-                    MemberInfoOnMyReviewResult.of(member, reviewRepository.countByUserId(memberId));
+                    MemberInfoOnMyReviewResult.of(
+                            member, reviewRepository.countAndSumLikesByUserId(memberId));
 
         } else {
             BaseballTeam baseballTeam = baseballTeamRepository.findById(member.getTeamId());
@@ -158,7 +159,7 @@ public class ReadReviewService implements ReadReviewUsecase {
             memberInfo =
                     MemberInfoOnMyReviewResult.of(
                             member,
-                            reviewRepository.countByUserId(memberId),
+                            reviewRepository.countAndSumLikesByUserId(memberId),
                             baseballTeam.getName());
         }
 

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/ReadReviewService.java
@@ -123,6 +123,10 @@ public class ReadReviewService implements ReadReviewUsecase {
             Integer size,
             ReviewType reviewType) {
 
+        if (reviewType == null) {
+            reviewType = ReviewType.VIEW;
+        }
+
         List<Review> reviews =
                 reviewRepository.findAllByUserId(
                         memberId, year, month, cursor, sortBy, size + 1, reviewType);
@@ -182,6 +186,9 @@ public class ReadReviewService implements ReadReviewUsecase {
 
     @Override
     public List<ReviewYearMonth> findReviewMonths(Long memberId, ReviewType reviewType) {
+        if (reviewType == null) {
+            reviewType = ReviewType.VIEW;
+        }
         return reviewRepository.findReviewMonthsByMemberId(memberId, reviewType);
     }
 


### PR DESCRIPTION
## 📌 개요 (필수)

- 시야 아카이빙 시야 후기/직관 후기 분리
- https://depromeet-15th.slack.com/archives/C075Z9K5QH4/p1724327340969699

<br>

## 🔨 작업 사항 (필수)

- [내 리뷰 조회 repository를 review type에 따라 조회하도록 업데이트](https://github.com/depromeet/SPOT-server/commit/64f2e3efe28e7aaa607381836c2503d0a26af451)
- [내 리뷰 조회 reviewType 디폴트를 VIEW로 설정](https://github.com/depromeet/SPOT-server/commit/d9b3124a7f26d255142bc12d89caf481f6a06a80)
- [유저별 리뷰 총 개수와 좋아요 합계를 가지는 ReviewCount 도메인 구현](https://github.com/depromeet/SPOT-server/commit/d526c8e6b6133320bafbe28ba6877569c93cb32d)
- [내 리뷰 조회에서 유저 정보 API 분리](https://github.com/depromeet/SPOT-server/commit/46811e825745b9334861279d51c3f15f9ed6ee01)
- [review type 관련한 쿼리문 버그 픽스](https://github.com/depromeet/SPOT-server/commit/c8e72b7e63c9faff9dac9a22971b1201bfea6692)

<br>

## ⚡️ 관심 리뷰 (선택)

- x

<br>

## 🌱 연관 내용 (선택)

- x

<br>

## 💻 실행 화면 (필수)
- 시야 아카이빙 유저 정보 조회

![image](https://github.com/user-attachments/assets/b35ba565-0b99-4c8d-a9da-e5bcfda8dc02)

- 시야 아카이빙 유저별 리뷰작성 년/월 조회

![image](https://github.com/user-attachments/assets/9feccd71-c1d5-4d45-a378-871bf9cd0a41)

- 시야 아카이빙 유저별 리뷰조회

![image](https://github.com/user-attachments/assets/31dae09c-5cb5-4801-b31d-05b5f72ba4bd)


