### PR TITLE
[BSVR-250] 어드민 리뷰 생성에서 ReviewType 때문에 insert에서 버그 발생

### DIFF
--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/processor/ReviewCreationProcessorImpl.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/processor/ReviewCreationProcessorImpl.java
@@ -84,6 +84,7 @@ public class ReviewCreationProcessorImpl implements ReviewCreationProcessor {
                 .seat(seat)
                 .dateTime(command.dateTime())
                 .content(command.content())
+                .reviewType(ReviewType.VIEW)
                 .build();
     }
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- https://depromeet-15th.slack.com/archives/C075Z9K5QH4/p1724584613683069
- 어드민 리뷰 생성에서 ReviewType 때문에 insert에서 버그 발생

<br>

## 🔨 작업 사항 (필수)

- `ReviewCreationProcessor`에서 insert하기 전 build하는 리뷰에 디폴트 값 `ReviewType.VIEW`로 `reviewType` 필드 추가

<br>

## ⚡️ 관심 리뷰 (선택)

- x

<br>

## 🌱 연관 내용 (선택)

- x

<br>

## 💻 실행 화면 (필수)

![image](https://github.com/user-attachments/assets/35697ccf-7a01-4373-9016-6702ca82b821)
