### PR TITLE
[BSVR-254] 탈퇴 시 리뷰 삭제 구현

### DIFF
--- a/application/src/main/java/org/depromeet/spot/application/member/controller/JwtCreateController.java
+++ b/application/src/main/java/org/depromeet/spot/application/member/controller/JwtCreateController.java
@@ -4,6 +4,7 @@ import org.depromeet.spot.application.common.jwt.JwtTokenUtil;
 import org.depromeet.spot.application.member.dto.response.JwtTokenResponse;
 import org.depromeet.spot.domain.member.Member;
 import org.depromeet.spot.domain.member.enums.MemberRole;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Tag(name = "Jwt 생성용")
 @RequestMapping("/api/v1/jwts")
+@Profile("!prod")
 public class JwtCreateController {
 
     private final JwtTokenUtil jwtTokenUtil;

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewJpaRepository.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewJpaRepository.java
@@ -42,6 +42,12 @@ public interface ReviewJpaRepository extends JpaRepository<ReviewEntity, Long> {
             @Param("memberId") Long memberId,
             @Param("deletedAt") LocalDateTime deletedAt);
 
+    @Modifying
+    @Query(
+            "UPDATE ReviewEntity r SET r.deletedAt = :deletedAt WHERE r.member.id = :memberId AND r.deletedAt IS NULL")
+    void softDeleteAllReviewOwnedByMemberId(
+            @Param("memberId") Long memberId, @Param("deletedAt") LocalDateTime deletedAt);
+
     @Query(
             "SELECT r FROM ReviewEntity r WHERE r.member.id = :memberId "
                     + "AND r.deletedAt IS NULL "

--- a/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewRepositoryImpl.java
+++ b/infrastructure/src/main/java/org/depromeet/spot/infrastructure/jpa/review/repository/ReviewRepositoryImpl.java
@@ -119,6 +119,11 @@ public class ReviewRepositoryImpl implements ReviewRepository {
     }
 
     @Override
+    public void softDeleteAllReviewOwnedByMemberId(Long memberId) {
+        reviewJpaRepository.softDeleteAllReviewOwnedByMemberId(memberId, LocalDateTime.now());
+    }
+
+    @Override
     public LocationInfo findLocationInfoByStadiumIdAndBlockCode(Long stadiumId, String blockCode) {
         return reviewCustomRepository.findLocationInfoByStadiumIdAndBlockCode(stadiumId, blockCode);
     }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/DeleteReviewUsecase.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/in/review/DeleteReviewUsecase.java
@@ -3,4 +3,6 @@ package org.depromeet.spot.usecase.port.in.review;
 public interface DeleteReviewUsecase {
 
     Long deleteReview(Long reviewId, Long memberId);
+
+    void deleteAllReviewOwnedByMemberId(Long memberId);
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewRepository.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/port/out/review/ReviewRepository.java
@@ -46,6 +46,8 @@ public interface ReviewRepository {
 
     Long softDeleteByIdAndMemberId(Long reviewId, Long memberId);
 
+    void softDeleteAllReviewOwnedByMemberId(Long memberId);
+
     LocationInfo findLocationInfoByStadiumIdAndBlockCode(Long stadiumId, String blockCode);
 
     Review findLastReviewByMemberId(Long memberId);

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/member/MemberService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/member/MemberService.java
@@ -13,6 +13,7 @@ import org.depromeet.spot.domain.team.BaseballTeam;
 import org.depromeet.spot.usecase.port.in.member.MemberUsecase;
 import org.depromeet.spot.usecase.port.in.member.ReadMemberUsecase;
 import org.depromeet.spot.usecase.port.in.member.level.ReadLevelUsecase;
+import org.depromeet.spot.usecase.port.in.review.DeleteReviewUsecase;
 import org.depromeet.spot.usecase.port.in.review.ReadReviewUsecase;
 import org.depromeet.spot.usecase.port.in.team.ReadBaseballTeamUsecase;
 import org.depromeet.spot.usecase.port.out.member.MemberRepository;
@@ -32,6 +33,7 @@ public class MemberService implements MemberUsecase {
     private final ReadMemberUsecase readMemberUsecase;
     private final ReadLevelUsecase readLevelUsecase;
     private final ReadBaseballTeamUsecase readBaseballTeamUsecase;
+    private final DeleteReviewUsecase deleteReviewUsecase;
 
     private final ReadReviewUsecase readReviewUsecase;
 
@@ -106,8 +108,13 @@ public class MemberService implements MemberUsecase {
         return MemberInfo.of(member, baseballTeam, reviewCntToLevelUp);
     }
 
+    @Transactional
     @Override
     public void softDelete(Long memberId) {
+
+        //        멤버 삭제 전 리뷰 삭제가 우선이 되어야함!
+        deleteReviewUsecase.deleteAllReviewOwnedByMemberId(memberId);
+
         memberRepository.updateDeletedAt(memberId, LocalDateTime.now());
     }
 }

--- a/usecase/src/main/java/org/depromeet/spot/usecase/service/review/DeleteReviewService.java
+++ b/usecase/src/main/java/org/depromeet/spot/usecase/service/review/DeleteReviewService.java
@@ -28,6 +28,11 @@ public class DeleteReviewService implements DeleteReviewUsecase {
         return deletedReviewId;
     }
 
+    @Override
+    public void deleteAllReviewOwnedByMemberId(Long memberId) {
+        reviewRepository.softDeleteAllReviewOwnedByMemberId(memberId);
+    }
+
     public void updateMemberLevel(Long memberId) {
         Member member = readMemberUsecase.findById(memberId);
         long reviewCnt = readReviewUsecase.countByMember(memberId);


### PR DESCRIPTION
## 📌 개요 (필수)

- 탈퇴 시 리뷰 삭제 구현
- Prod에서 jwt 토큰 생성 API 비활성화

<br>

## 🔨 작업 사항 (필수)

- 탈퇴 시 리뷰 삭제 구현
- Prod에서 jwt 토큰 생성 API 비활성화
  - jwt 토큰 생성 API가 권한이 필요하거나 한 게 아니라서 Prod에서는 사용할 수 없게 비활성화 함!

<br>

## ⚡️ 관심 리뷰 (선택)

- 탈퇴했을 때 정보 삭제하는 것들도 이벤트나 큐로 처리하는 게 좋을까 고민 중...

<br>

## 💻 실행 화면 (필수)

- 탈퇴하면, 리뷰도 정상 삭제 완료 확인!
![image](https://github.com/user-attachments/assets/5c914a2a-05d6-405e-8590-57ac5762dab8)
